### PR TITLE
Add moderator management feature

### DIFF
--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -102,13 +102,13 @@ export default function Sidebar({ onClose, isMobile = false }: SidebarProps) {
             path: AppRoutes.Moderators,
             icon: <Users size={20} />,
           },
+          {
+            label: 'Support',
+            path: AppRoutes.Support,
+            icon: <LifeBuoy size={20} />,
+          },
         ]
       : []),
-    {
-      label: 'Support',
-      path: AppRoutes.Support,
-      icon: <LifeBuoy size={20} />,
-    },
   ];
 
   const navItems = allNavItems;

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -12,11 +12,13 @@ import {
   Monitor,
   Video,
   LifeBuoy,
+  Users,
 } from 'lucide-react';
 import { AppRoutes } from '@/constants';
 import { Button } from '@/components/ui';
 import { cn } from '@/utils';
 import { useSidebarState } from '@/hooks';
+import { useAuthStore } from '@/store';
 
 interface SidebarProps {
   onClose?: () => void;
@@ -29,6 +31,7 @@ interface SidebarProps {
 export default function Sidebar({ onClose, isMobile = false }: SidebarProps) {
   const [collapsed, toggleSidebar] = useSidebarState(false);
   const location = useLocation();
+  const role = useAuthStore(s => s.role);
 
   /**
    * Determines if a navigation item should be active
@@ -44,7 +47,9 @@ export default function Sidebar({ onClose, isMobile = false }: SidebarProps) {
     return location.pathname === path || location.pathname.startsWith(path + '/');
   };
 
-  const navItems = [
+  const isAdmin = role === 'admin';
+
+  const allNavItems = [
     {
       label: 'Home',
       path: AppRoutes.Home,
@@ -75,27 +80,38 @@ export default function Sidebar({ onClose, isMobile = false }: SidebarProps) {
       path: AppRoutes.YouTubeVideos,
       icon: <Video size={20} />,
     },
-    {
-      label: 'Screens',
-      path: AppRoutes.Screens,
-      icon: <Monitor size={20} />,
-    },
-    {
-      label: 'Prayer Timings',
-      path: AppRoutes.PrayerTimings,
-      icon: <Clock size={20} />,
-    },
-    {
-      label: 'Settings',
-      path: AppRoutes.Settings,
-      icon: <Settings size={20} />,
-    },
+    ...(isAdmin
+      ? [
+          {
+            label: 'Screens',
+            path: AppRoutes.Screens,
+            icon: <Monitor size={20} />,
+          },
+          {
+            label: 'Prayer Timings',
+            path: AppRoutes.PrayerTimings,
+            icon: <Clock size={20} />,
+          },
+          {
+            label: 'Settings',
+            path: AppRoutes.Settings,
+            icon: <Settings size={20} />,
+          },
+          {
+            label: 'Moderators',
+            path: AppRoutes.Moderators,
+            icon: <Users size={20} />,
+          },
+        ]
+      : []),
     {
       label: 'Support',
       path: AppRoutes.Support,
       icon: <LifeBuoy size={20} />,
     },
   ];
+
+  const navItems = allNavItems;
 
   return (
     <div className='relative h-screen flex overflow-hidden'>

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -25,5 +25,6 @@ export enum AppRoutes {
   SettingsHijri = '/admin/settings/hijri-adjustment',
   SettingsAccount = '/admin/settings/account',
   SettingsPrayerTimes = '/admin/settings/prayer-times',
+  Moderators = '/admin/moderators',
   Support = '/admin/support',
 }

--- a/src/hooks/useFetchDisplayData.ts
+++ b/src/hooks/useFetchDisplayData.ts
@@ -50,13 +50,13 @@ export function useFetchDisplayData(): ReturnType {
   const [userSettings, setUserSettings] = useState<Settings | null>(null);
 
   const { masjidProfile, displayScreen, setDisplayScreen, signOut } = useDisplayStore();
-  const userId = masjidProfile?.user_id;
+  const masjidId = masjidProfile?.id;
   const screenId = displayScreen?.id;
 
   useEffect(() => {
     const abortController = new AbortController();
 
-    if (!userId || !screenId) return () => abortController.abort();
+    if (!masjidId || !screenId) return () => abortController.abort();
 
     const req = async () => {
       setFetching(true);
@@ -64,7 +64,7 @@ export function useFetchDisplayData(): ReturnType {
 
       try {
         const [settings, screenContentRows, latestScreen] = await Promise.all([
-          getSettings(userId),
+          getSettings(masjidId),
           getVisibleScreenContent(screenId),
           getScreenById(screenId),
         ]);
@@ -143,7 +143,7 @@ export function useFetchDisplayData(): ReturnType {
     return () => {
       abortController.abort();
     };
-  }, [userId, screenId]);
+  }, [masjidId, screenId]);
 
   return {
     isLoading: fetching,

--- a/src/hooks/usePrayerTimings.ts
+++ b/src/hooks/usePrayerTimings.ts
@@ -26,7 +26,7 @@ export function usePrayerTimings(enabled: boolean = true): ReturnType {
   const [prayerTimeSettings, setPrayerTimeSettings] = useState<PrayerTimes | null>(null);
 
   const { masjidProfile } = useDisplayStore();
-  const userId = masjidProfile?.user_id;
+  const masjidId = masjidProfile?.id;
 
   const fetchPrayerTimes = useCallback(
     async (
@@ -83,7 +83,7 @@ export function usePrayerTimings(enabled: boolean = true): ReturnType {
   useEffect(() => {
     const abortController = new AbortController();
 
-    if (!enabled || !userId) return () => abortController.abort();
+    if (!enabled || !masjidId) return () => abortController.abort();
 
     const fetchData = async () => {
       setIsLoading(true);
@@ -91,8 +91,8 @@ export function usePrayerTimings(enabled: boolean = true): ReturnType {
 
       try {
         const [userSettings, prayerTimeSettings] = await Promise.all([
-          getSettings(userId),
-          getPrayerAdjustments(userId),
+          getSettings(masjidId),
+          getPrayerAdjustments(masjidId),
         ]);
         await fetchPrayerTimes(userSettings, prayerTimeSettings, abortController.signal);
       } catch (error) {
@@ -108,7 +108,7 @@ export function usePrayerTimings(enabled: boolean = true): ReturnType {
     return () => {
       abortController.abort();
     };
-  }, [enabled, fetchPrayerTimes, userId]);
+  }, [enabled, fetchPrayerTimes, masjidId]);
 
   return {
     isLoading,

--- a/src/lib/supabase/helpers.ts
+++ b/src/lib/supabase/helpers.ts
@@ -63,6 +63,20 @@ export async function getMasjidMembership(): Promise<{ masjid_id: string; role: 
 }
 
 /**
+ * Updates the last_active_at timestamp for the current user's membership.
+ * Called on login to track moderator activity.
+ */
+export async function updateLastActive(): Promise<void> {
+  const user = await getCurrentUser();
+  if (!user) return;
+
+  await supabase
+    .from('masjid_members')
+    .update({ last_active_at: new Date().toISOString() })
+    .eq('user_id', user.id);
+}
+
+/**
  * Helper to handle common Supabase errors
  * @param error The PostgrestError to handle
  * @param customMessage Optional custom error message

--- a/src/lib/supabase/helpers.ts
+++ b/src/lib/supabase/helpers.ts
@@ -1,7 +1,7 @@
 import { AppRoutes } from '@/constants';
 import supabase from './index';
 import { PostgrestError, type Session } from '@supabase/supabase-js';
-import type { SupabaseBuckets, SupabaseFolders } from '@/types';
+import type { MemberRole, SupabaseBuckets, SupabaseFolders } from '@/types';
 
 /**
  * Helper to subscribe to auth changes
@@ -42,6 +42,24 @@ export async function getCurrentUser() {
   }
 
   return data.user;
+}
+
+/**
+ * Gets the masjid membership for the current authenticated user
+ * @returns The masjid_id and role for the current user
+ */
+export async function getMasjidMembership(): Promise<{ masjid_id: string; role: MemberRole }> {
+  const user = await getCurrentUser();
+  if (!user) throw new Error('User not authenticated');
+
+  const { data, error } = await supabase
+    .from('masjid_members')
+    .select('masjid_id, role')
+    .eq('user_id', user.id)
+    .single();
+
+  if (error || !data) throw new Error('No masjid membership found');
+  return data as { masjid_id: string; role: MemberRole };
 }
 
 /**

--- a/src/lib/supabase/services/announcements.ts
+++ b/src/lib/supabase/services/announcements.ts
@@ -2,19 +2,18 @@ import { SupabaseTables, type Announcement } from '@/types';
 import type { AnnouncementData } from '../../zod';
 import {
   getCurrentUser,
-  fetchByColumn,
+  getMasjidMembership,
   updateRecord,
   insertRecord,
   fetchByMultipleConditions,
 } from '../helpers';
 import { removeScreenAssignments } from './screens';
 
-export async function getAnnouncements(userId?: string): Promise<Announcement[]> {
-  const user = userId ? { id: userId } : await getCurrentUser();
-  if (!user) throw new Error('User not authenticated');
+export async function getAnnouncements(masjidId?: string): Promise<Announcement[]> {
+  const effectiveMasjidId = masjidId || (await getMasjidMembership()).masjid_id;
 
   const conditions = [
-    { column: 'user_id', value: user.id },
+    { column: 'masjid_id', value: effectiveMasjidId },
     { column: 'archived', value: false, isNull: true },
   ];
 
@@ -24,10 +23,12 @@ export async function getAnnouncements(userId?: string): Promise<Announcement[]>
 export async function upsertAnnouncement(announcement: AnnouncementData & { id?: string }) {
   const user = await getCurrentUser();
   if (!user) throw new Error('User not authenticated');
+  const { masjid_id } = await getMasjidMembership();
 
   const announcementToUpsert: Partial<Announcement> = {
     ...announcement,
     user_id: user.id,
+    masjid_id,
     updated_at: new Date().toISOString(),
     archived: false,
   };
@@ -46,14 +47,6 @@ export async function upsertAnnouncement(announcement: AnnouncementData & { id?:
 }
 
 export async function deleteAnnouncement(id: string): Promise<boolean> {
-  const user = await getCurrentUser();
-  if (!user) throw new Error('User not authenticated');
-
-  const items = await fetchByColumn<Announcement>(SupabaseTables.Announcements, 'id', id);
-
-  if (items.length === 0) throw new Error('Item not found');
-  if (items[0].user_id !== user.id) throw new Error('Not authorized to delete this item');
-
   const updates: Partial<Announcement> = { archived: true, updated_at: new Date().toISOString() };
 
   await updateRecord<Announcement>(SupabaseTables.Announcements, id, updates);

--- a/src/lib/supabase/services/ayat-and-hadith.ts
+++ b/src/lib/supabase/services/ayat-and-hadith.ts
@@ -2,19 +2,18 @@ import { SupabaseTables, type AyatAndHadith } from '@/types';
 import type { AyatAndHadithData } from '../../zod';
 import {
   getCurrentUser,
-  fetchByColumn,
+  getMasjidMembership,
   updateRecord,
   insertRecord,
   fetchByMultipleConditions,
 } from '../helpers';
 import { removeScreenAssignments } from './screens';
 
-export async function getAyatAndHadith(userId?: string): Promise<AyatAndHadith[]> {
-  const user = userId ? { id: userId } : await getCurrentUser();
-  if (!user) throw new Error('User not authenticated');
+export async function getAyatAndHadith(masjidId?: string): Promise<AyatAndHadith[]> {
+  const effectiveMasjidId = masjidId || (await getMasjidMembership()).masjid_id;
 
   const conditions = [
-    { column: 'user_id', value: user.id },
+    { column: 'masjid_id', value: effectiveMasjidId },
     { column: 'archived', value: false, isNull: true },
   ];
 
@@ -24,10 +23,12 @@ export async function getAyatAndHadith(userId?: string): Promise<AyatAndHadith[]
 export async function upsertAyatAndHadith(ayatAndHadith: AyatAndHadithData & { id?: string }) {
   const user = await getCurrentUser();
   if (!user) throw new Error('User not authenticated');
+  const { masjid_id } = await getMasjidMembership();
 
   const ayatAndHadithToUpsert: Partial<AyatAndHadith> = {
     ...ayatAndHadith,
     user_id: user.id,
+    masjid_id,
     updated_at: new Date().toISOString(),
     archived: false,
   };
@@ -46,14 +47,6 @@ export async function upsertAyatAndHadith(ayatAndHadith: AyatAndHadithData & { i
 }
 
 export async function deleteAyatAndHadith(id: string): Promise<boolean> {
-  const user = await getCurrentUser();
-  if (!user) throw new Error('User not authenticated');
-
-  const items = await fetchByColumn<AyatAndHadith>(SupabaseTables.AyatAndHadith, 'id', id);
-
-  if (items.length === 0) throw new Error('Item not found');
-  if (items[0].user_id !== user.id) throw new Error('Not authorized to delete this item');
-
   const updates: Partial<AyatAndHadith> = { archived: true, updated_at: new Date().toISOString() };
 
   await updateRecord<AyatAndHadith>(SupabaseTables.AyatAndHadith, id, updates);

--- a/src/lib/supabase/services/events.ts
+++ b/src/lib/supabase/services/events.ts
@@ -2,19 +2,18 @@ import { SupabaseTables, type Event } from '@/types';
 import type { EventData } from '../../zod';
 import {
   getCurrentUser,
-  fetchByColumn,
+  getMasjidMembership,
   updateRecord,
   insertRecord,
   fetchByMultipleConditions,
 } from '../helpers';
 import { removeScreenAssignments } from './screens';
 
-export async function getEvents(userId?: string): Promise<Event[]> {
-  const user = userId ? { id: userId } : await getCurrentUser();
-  if (!user) throw new Error('User not authenticated');
+export async function getEvents(masjidId?: string): Promise<Event[]> {
+  const effectiveMasjidId = masjidId || (await getMasjidMembership()).masjid_id;
 
   const conditions = [
-    { column: 'user_id', value: user.id },
+    { column: 'masjid_id', value: effectiveMasjidId },
     { column: 'archived', value: false, isNull: true },
   ];
 
@@ -24,10 +23,12 @@ export async function getEvents(userId?: string): Promise<Event[]> {
 export async function upsertEvent(event: EventData & { id?: string }) {
   const user = await getCurrentUser();
   if (!user) throw new Error('User not authenticated');
+  const { masjid_id } = await getMasjidMembership();
 
   const eventToUpsert: Partial<Event> = {
     ...event,
     user_id: user.id,
+    masjid_id,
     updated_at: new Date().toISOString(),
     archived: false,
   };
@@ -42,14 +43,6 @@ export async function upsertEvent(event: EventData & { id?: string }) {
 }
 
 export async function deleteEvent(id: string): Promise<boolean> {
-  const user = await getCurrentUser();
-  if (!user) throw new Error('User not authenticated');
-
-  const items = await fetchByColumn<Event>(SupabaseTables.Events, 'id', id);
-
-  if (items.length === 0) throw new Error('Item not found');
-  if (items[0].user_id !== user.id) throw new Error('Not authorized to delete this item');
-
   const updates: Partial<Event> = { archived: true, updated_at: new Date().toISOString() };
 
   await updateRecord<Event>(SupabaseTables.Events, id, updates);

--- a/src/lib/supabase/services/index.ts
+++ b/src/lib/supabase/services/index.ts
@@ -7,3 +7,4 @@ export * from './prayer-times';
 export * from './settings';
 export * from './screens';
 export * from './youtube-videos';
+export * from './moderators';

--- a/src/lib/supabase/services/masjid-profile.ts
+++ b/src/lib/supabase/services/masjid-profile.ts
@@ -1,35 +1,44 @@
 import { SupabaseBuckets, SupabaseTables, type MasjidProfile } from '@/types';
 import type { MasjidProfileData } from '../../zod';
-import { getCurrentUser, uploadFile, fetchByColumn, updateRecord, insertRecord } from '../helpers';
+import {
+  getCurrentUser,
+  getMasjidMembership,
+  uploadFile,
+  fetchByColumn,
+  fetchById,
+  updateRecord,
+  insertRecord,
+} from '../helpers';
 
 /**
  * Gets the masjid profile for the current authenticated user
  * @returns Promise resolving to masjid profile or null if not found
  */
 export async function getMasjidProfile(): Promise<MasjidProfile | null> {
-  const user = await getCurrentUser();
-  if (!user) throw new Error('User not authenticated');
+  try {
+    const { masjid_id } = await getMasjidMembership();
+    return await fetchById<MasjidProfile>(SupabaseTables.MasjidProfiles, masjid_id);
+  } catch {
+    // Fallback for users who haven't been added to masjid_members yet (e.g. during registration)
+    const user = await getCurrentUser();
+    if (!user) throw new Error('User not authenticated');
 
-  const profiles = await fetchByColumn<MasjidProfile>(
-    SupabaseTables.MasjidProfiles,
-    'user_id',
-    user.id
-  );
-  return profiles.length > 0 ? profiles[0] : null;
+    const profiles = await fetchByColumn<MasjidProfile>(
+      SupabaseTables.MasjidProfiles,
+      'user_id',
+      user.id
+    );
+    return profiles.length > 0 ? profiles[0] : null;
+  }
 }
 
 /**
- * Gets a masjid profile by user ID
- * @param userId The user ID to search for
+ * Gets a masjid profile by masjid ID
+ * @param masjidId The masjid ID to search for
  * @returns Promise resolving to masjid profile or null if not found
  */
-export async function getMasjidProfileByUserId(userId: string): Promise<MasjidProfile | null> {
-  const profiles = await fetchByColumn<MasjidProfile>(
-    SupabaseTables.MasjidProfiles,
-    'user_id',
-    userId
-  );
-  return profiles.length > 0 ? profiles[0] : null;
+export async function getMasjidProfileByMasjidId(masjidId: string): Promise<MasjidProfile | null> {
+  return await fetchById<MasjidProfile>(SupabaseTables.MasjidProfiles, masjidId);
 }
 
 /**

--- a/src/lib/supabase/services/moderators.ts
+++ b/src/lib/supabase/services/moderators.ts
@@ -12,9 +12,25 @@ export async function getModerators(): Promise<ModeratorWithEmail[]> {
   return [];
 }
 
-export async function createModerator(email: string, password: string): Promise<void> {
+export async function updateModerator(
+  userId: string,
+  updates: { name?: string; email?: string }
+): Promise<void> {
+  const { data, error } = await supabase.functions.invoke('update-moderator', {
+    body: { user_id: userId, ...updates },
+  });
+
+  if (error) throw new Error(error.message || 'Failed to update moderator');
+  if (data?.error) throw new Error(data.error);
+}
+
+export async function createModerator(
+  email: string,
+  password: string,
+  name: string
+): Promise<void> {
   const { data, error } = await supabase.functions.invoke('create-moderator', {
-    body: { email, password },
+    body: { email, password, name },
   });
 
   if (error) throw new Error(error.message || 'Failed to create moderator');

--- a/src/lib/supabase/services/moderators.ts
+++ b/src/lib/supabase/services/moderators.ts
@@ -1,0 +1,31 @@
+import type { MasjidMember } from '@/types';
+import supabase from '../index';
+
+export type ModeratorWithEmail = MasjidMember & { email: string };
+
+export async function getModerators(): Promise<ModeratorWithEmail[]> {
+  const { data, error } = await supabase.functions.invoke('get-moderators');
+
+  if (error) throw new Error(error.message || 'Failed to fetch moderators');
+  if (Array.isArray(data)) return data;
+  if (data?.error) throw new Error(data.error);
+  return [];
+}
+
+export async function createModerator(email: string, password: string): Promise<void> {
+  const { data, error } = await supabase.functions.invoke('create-moderator', {
+    body: { email, password },
+  });
+
+  if (error) throw new Error(error.message || 'Failed to create moderator');
+  if (data?.error) throw new Error(data.error);
+}
+
+export async function revokeModerator(userId: string): Promise<void> {
+  const { data, error } = await supabase.functions.invoke('revoke-moderator', {
+    body: { user_id: userId },
+  });
+
+  if (error) throw new Error(error.message || 'Failed to revoke moderator');
+  if (data?.error) throw new Error(data.error);
+}

--- a/src/lib/supabase/services/moderators.ts
+++ b/src/lib/supabase/services/moderators.ts
@@ -21,6 +21,15 @@ export async function createModerator(email: string, password: string): Promise<
   if (data?.error) throw new Error(data.error);
 }
 
+export async function resetModeratorPassword(userId: string, password: string): Promise<void> {
+  const { data, error } = await supabase.functions.invoke('reset-moderator-password', {
+    body: { user_id: userId, password },
+  });
+
+  if (error) throw new Error(error.message || 'Failed to reset password');
+  if (data?.error) throw new Error(data.error);
+}
+
 export async function revokeModerator(userId: string): Promise<void> {
   const { data, error } = await supabase.functions.invoke('revoke-moderator', {
     body: { user_id: userId },

--- a/src/lib/supabase/services/moderators.ts
+++ b/src/lib/supabase/services/moderators.ts
@@ -3,12 +3,26 @@ import supabase from '../index';
 
 export type ModeratorWithEmail = MasjidMember & { email: string };
 
+async function handleError(error: Error | null, fallback: string): Promise<never> {
+  // FunctionsHttpError stores the raw Response in error.context
+  // We need to parse the JSON body to get the actual error message
+  if (error && 'context' in error && error.context instanceof Response) {
+    try {
+      const body = await error.context.json();
+      if (body?.error) throw new Error(body.error);
+    } catch (e) {
+      if (e instanceof Error && e.message !== error.message) throw e;
+    }
+  }
+  throw new Error(error?.message || fallback);
+}
+
 export async function getModerators(): Promise<ModeratorWithEmail[]> {
   const { data, error } = await supabase.functions.invoke('get-moderators');
 
-  if (error) throw new Error(error.message || 'Failed to fetch moderators');
-  if (Array.isArray(data)) return data;
+  if (error) await handleError(error, 'Failed to fetch moderators');
   if (data?.error) throw new Error(data.error);
+  if (Array.isArray(data)) return data;
   return [];
 }
 
@@ -20,7 +34,7 @@ export async function updateModerator(
     body: { user_id: userId, ...updates },
   });
 
-  if (error) throw new Error(error.message || 'Failed to update moderator');
+  if (error) await handleError(error, 'Failed to update moderator');
   if (data?.error) throw new Error(data.error);
 }
 
@@ -33,7 +47,7 @@ export async function createModerator(
     body: { email, password, name },
   });
 
-  if (error) throw new Error(error.message || 'Failed to create moderator');
+  if (error) await handleError(error, 'Failed to create moderator');
   if (data?.error) throw new Error(data.error);
 }
 
@@ -42,7 +56,7 @@ export async function resetModeratorPassword(userId: string, password: string): 
     body: { user_id: userId, password },
   });
 
-  if (error) throw new Error(error.message || 'Failed to reset password');
+  if (error) await handleError(error, 'Failed to reset password');
   if (data?.error) throw new Error(data.error);
 }
 
@@ -51,6 +65,6 @@ export async function revokeModerator(userId: string): Promise<void> {
     body: { user_id: userId },
   });
 
-  if (error) throw new Error(error.message || 'Failed to revoke moderator');
+  if (error) await handleError(error, 'Failed to revoke moderator');
   if (data?.error) throw new Error(data.error);
 }

--- a/src/lib/supabase/services/posts.ts
+++ b/src/lib/supabase/services/posts.ts
@@ -2,7 +2,7 @@ import { SupabaseBuckets, SupabaseTables, type Post } from '@/types';
 import type { PostData } from '../../zod';
 import {
   getCurrentUser,
-  fetchByColumn,
+  getMasjidMembership,
   updateRecord,
   insertRecord,
   fetchByMultipleConditions,
@@ -10,12 +10,11 @@ import {
 } from '../helpers';
 import { removeScreenAssignments } from './screens';
 
-export async function getPosts(userId?: string): Promise<Post[]> {
-  const user = userId ? { id: userId } : await getCurrentUser();
-  if (!user) throw new Error('User not authenticated');
+export async function getPosts(masjidId?: string): Promise<Post[]> {
+  const effectiveMasjidId = masjidId || (await getMasjidMembership()).masjid_id;
 
   const conditions = [
-    { column: 'user_id', value: user.id },
+    { column: 'masjid_id', value: effectiveMasjidId },
     { column: 'archived', value: false, isNull: true },
   ];
 
@@ -25,6 +24,7 @@ export async function getPosts(userId?: string): Promise<Post[]> {
 export async function upsertPost(post: PostData & { id?: string }, imageFile: File | null) {
   const user = await getCurrentUser();
   if (!user) throw new Error('User not authenticated');
+  const { masjid_id } = await getMasjidMembership();
 
   let imageUrl = undefined;
 
@@ -35,6 +35,7 @@ export async function upsertPost(post: PostData & { id?: string }, imageFile: Fi
   const postToUpsert: Partial<Post> = {
     ...post,
     user_id: user.id,
+    masjid_id,
     updated_at: new Date().toISOString(),
     archived: false,
     ...(imageUrl && { image_url: imageUrl }),
@@ -50,14 +51,6 @@ export async function upsertPost(post: PostData & { id?: string }, imageFile: Fi
 }
 
 export async function deletePost(id: string): Promise<boolean> {
-  const user = await getCurrentUser();
-  if (!user) throw new Error('User not authenticated');
-
-  const items = await fetchByColumn<Post>(SupabaseTables.Posts, 'id', id);
-
-  if (items.length === 0) throw new Error('Item not found');
-  if (items[0].user_id !== user.id) throw new Error('Not authorized to delete this item');
-
   const updates: Partial<Post> = { archived: true, updated_at: new Date().toISOString() };
 
   await updateRecord<Post>(SupabaseTables.Posts, id, updates);

--- a/src/lib/supabase/services/prayer-times.ts
+++ b/src/lib/supabase/services/prayer-times.ts
@@ -1,26 +1,31 @@
 import { SupabaseTables, type PrayerTimes } from '@/types';
 import type { PrayerAdjustmentsFormData } from '../../zod';
-import { getCurrentUser, fetchByColumn, updateRecord, insertRecord } from '../helpers';
+import {
+  getCurrentUser,
+  getMasjidMembership,
+  fetchByColumn,
+  updateRecord,
+  insertRecord,
+} from '../helpers';
 
 /**
- * Gets prayer adjustments for a user
- * @param userId Optional user ID, if not provided uses current authenticated user
+ * Gets prayer adjustments for a masjid
+ * @param masjidId Optional masjid ID, if not provided uses current user's masjid
  * @returns Promise resolving to prayer adjustments or null if not found
  */
-export async function getPrayerAdjustments(userId?: string): Promise<PrayerTimes | null> {
-  const user = userId ? { id: userId } : await getCurrentUser();
-  if (!user) throw new Error('User not authenticated');
+export async function getPrayerAdjustments(masjidId?: string): Promise<PrayerTimes | null> {
+  const effectiveMasjidId = masjidId || (await getMasjidMembership()).masjid_id;
 
   const prayerTimes = await fetchByColumn<PrayerTimes>(
     SupabaseTables.PrayerTimes,
-    'user_id',
-    user.id
+    'masjid_id',
+    effectiveMasjidId
   );
   return prayerTimes.length > 0 ? prayerTimes[0] : null;
 }
 
 /**
- * Saves or updates prayer adjustments for the current user
+ * Saves or updates prayer adjustments for the current user's masjid
  * @param settings The prayer adjustments data to save
  * @returns Promise resolving to the saved prayer adjustments
  */
@@ -29,12 +34,14 @@ export async function savePrayerAdjustments(
 ): Promise<PrayerTimes> {
   const user = await getCurrentUser();
   if (!user) throw new Error('User not authenticated');
+  const { masjid_id } = await getMasjidMembership();
 
-  const existing = await getPrayerAdjustments();
+  const existing = await getPrayerAdjustments(masjid_id);
 
   const settingsToUpsert: Partial<PrayerTimes> = {
     ...settings,
     user_id: user.id,
+    masjid_id,
     updated_at: new Date().toISOString(),
   };
 

--- a/src/lib/supabase/services/screens.ts
+++ b/src/lib/supabase/services/screens.ts
@@ -5,15 +5,20 @@ import {
   type ScreenContentType,
 } from '@/types';
 import type { ScreenData } from '../../zod';
-import { getCurrentUser, fetchByColumn, updateRecord, insertRecord } from '../helpers';
+import {
+  getCurrentUser,
+  getMasjidMembership,
+  fetchByColumn,
+  updateRecord,
+  insertRecord,
+} from '../helpers';
 import { generateScreenCode } from '@/utils';
 import supabase from '../index';
 
 export async function getScreens(): Promise<DisplayScreen[]> {
-  const user = await getCurrentUser();
-  if (!user) throw new Error('User not authenticated');
+  const { masjid_id } = await getMasjidMembership();
 
-  return await fetchByColumn<DisplayScreen>(SupabaseTables.DisplayScreens, 'user_id', user.id);
+  return await fetchByColumn<DisplayScreen>(SupabaseTables.DisplayScreens, 'masjid_id', masjid_id);
 }
 
 export async function getScreenById(id: string): Promise<DisplayScreen | null> {
@@ -29,10 +34,12 @@ export async function getScreenByCode(code: string): Promise<DisplayScreen | nul
 export async function createScreen(data: ScreenData): Promise<DisplayScreen> {
   const user = await getCurrentUser();
   if (!user) throw new Error('User not authenticated');
+  const { masjid_id } = await getMasjidMembership();
 
   const screenToInsert: Partial<DisplayScreen> = {
     ...data,
     user_id: user.id,
+    masjid_id,
     code: generateScreenCode(),
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
@@ -42,13 +49,6 @@ export async function createScreen(data: ScreenData): Promise<DisplayScreen> {
 }
 
 export async function updateScreen(id: string, data: ScreenData): Promise<DisplayScreen> {
-  const user = await getCurrentUser();
-  if (!user) throw new Error('User not authenticated');
-
-  const screens = await fetchByColumn<DisplayScreen>(SupabaseTables.DisplayScreens, 'id', id);
-  if (screens.length === 0) throw new Error('Screen not found');
-  if (screens[0].user_id !== user.id) throw new Error('Not authorized to update this screen');
-
   return await updateRecord<DisplayScreen>(SupabaseTables.DisplayScreens, id, {
     ...data,
     updated_at: new Date().toISOString(),
@@ -56,13 +56,6 @@ export async function updateScreen(id: string, data: ScreenData): Promise<Displa
 }
 
 export async function deleteScreen(id: string): Promise<boolean> {
-  const user = await getCurrentUser();
-  if (!user) throw new Error('User not authenticated');
-
-  const screens = await fetchByColumn<DisplayScreen>(SupabaseTables.DisplayScreens, 'id', id);
-  if (screens.length === 0) throw new Error('Screen not found');
-  if (screens[0].user_id !== user.id) throw new Error('Not authorized to delete this screen');
-
   const { error } = await supabase.from(SupabaseTables.DisplayScreens).delete().eq('id', id);
   if (error) throw error;
   return true;

--- a/src/lib/supabase/services/settings.ts
+++ b/src/lib/supabase/services/settings.ts
@@ -1,13 +1,22 @@
 import { SupabaseTables, type Settings, Theme } from '@/types';
 import { HijriCalculationMethod, CalculationMethod, JuristicSchool } from '@/constants';
-import { getCurrentUser, insertRecord, fetchByColumn, updateRecord } from '../helpers';
+import {
+  getCurrentUser,
+  getMasjidMembership,
+  insertRecord,
+  fetchByColumn,
+  updateRecord,
+} from '../helpers';
 
-export async function getSettings(userId?: string): Promise<Settings | null> {
+export async function getSettings(masjidId?: string): Promise<Settings | null> {
   try {
-    const user = userId ? { id: userId } : await getCurrentUser();
-    if (!user) throw new Error('User not authenticated');
+    const effectiveMasjidId = masjidId || (await getMasjidMembership()).masjid_id;
 
-    const results = await fetchByColumn<Settings>(SupabaseTables.Settings, 'user_id', user.id);
+    const results = await fetchByColumn<Settings>(
+      SupabaseTables.Settings,
+      'masjid_id',
+      effectiveMasjidId
+    );
 
     if (results.length > 0) {
       return results[0];
@@ -23,9 +32,11 @@ export async function getSettings(userId?: string): Promise<Settings | null> {
 export async function createDefaultSettings(): Promise<Settings> {
   const user = await getCurrentUser();
   if (!user) throw new Error('User not authenticated');
+  const { masjid_id } = await getMasjidMembership();
 
   const settingsData: Partial<Settings> = {
     user_id: user.id,
+    masjid_id,
     theme: Theme.Theme1,
     hijri_calculation_method: HijriCalculationMethod.Umm_al_Qura,
     hijri_offset: 0,

--- a/src/lib/supabase/services/youtube-videos.ts
+++ b/src/lib/supabase/services/youtube-videos.ts
@@ -2,19 +2,18 @@ import { SupabaseTables, type YouTubeVideo } from '@/types';
 import type { YouTubeVideoData } from '../../zod';
 import {
   getCurrentUser,
-  fetchByColumn,
+  getMasjidMembership,
   updateRecord,
   insertRecord,
   fetchByMultipleConditions,
 } from '../helpers';
 import { removeScreenAssignments } from './screens';
 
-export async function getYouTubeVideos(userId?: string): Promise<YouTubeVideo[]> {
-  const user = userId ? { id: userId } : await getCurrentUser();
-  if (!user) throw new Error('User not authenticated');
+export async function getYouTubeVideos(masjidId?: string): Promise<YouTubeVideo[]> {
+  const effectiveMasjidId = masjidId || (await getMasjidMembership()).masjid_id;
 
   const conditions = [
-    { column: 'user_id', value: user.id },
+    { column: 'masjid_id', value: effectiveMasjidId },
     { column: 'archived', value: false, isNull: true },
   ];
 
@@ -24,10 +23,12 @@ export async function getYouTubeVideos(userId?: string): Promise<YouTubeVideo[]>
 export async function upsertYouTubeVideo(video: YouTubeVideoData & { id?: string }) {
   const user = await getCurrentUser();
   if (!user) throw new Error('User not authenticated');
+  const { masjid_id } = await getMasjidMembership();
 
   const record: Partial<YouTubeVideo> = {
     ...video,
     user_id: user.id,
+    masjid_id,
     updated_at: new Date().toISOString(),
     archived: false,
   };
@@ -41,14 +42,6 @@ export async function upsertYouTubeVideo(video: YouTubeVideoData & { id?: string
 }
 
 export async function deleteYouTubeVideo(id: string): Promise<boolean> {
-  const user = await getCurrentUser();
-  if (!user) throw new Error('User not authenticated');
-
-  const items = await fetchByColumn<YouTubeVideo>(SupabaseTables.YouTubeVideos, 'id', id);
-
-  if (items.length === 0) throw new Error('Item not found');
-  if (items[0].user_id !== user.id) throw new Error('Not authorized to delete this item');
-
   const updates: Partial<YouTubeVideo> = { archived: true, updated_at: new Date().toISOString() };
 
   await updateRecord<YouTubeVideo>(SupabaseTables.YouTubeVideos, id, updates);

--- a/src/lib/zod.ts
+++ b/src/lib/zod.ts
@@ -174,6 +174,7 @@ export type ScreenData = z.infer<typeof screenSchema>;
 
 export const createModeratorSchema = z
   .object({
+    name: z.string().min(1, 'Name is required'),
     email: z.string().email('Please enter a valid email address'),
     password: z.string().min(8, 'Password must be at least 8 characters'),
     confirmPassword: z.string().min(8, 'Password must be at least 8 characters'),
@@ -184,6 +185,13 @@ export const createModeratorSchema = z
   });
 
 export type CreateModeratorData = z.infer<typeof createModeratorSchema>;
+
+export const updateModeratorSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Please enter a valid email address'),
+});
+
+export type UpdateModeratorData = z.infer<typeof updateModeratorSchema>;
 
 export const resetModeratorPasswordSchema = z
   .object({

--- a/src/lib/zod.ts
+++ b/src/lib/zod.ts
@@ -171,3 +171,16 @@ export const screenSchema = z.object({
 });
 
 export type ScreenData = z.infer<typeof screenSchema>;
+
+export const createModeratorSchema = z
+  .object({
+    email: z.string().email('Please enter a valid email address'),
+    password: z.string().min(8, 'Password must be at least 8 characters'),
+    confirmPassword: z.string().min(8, 'Password must be at least 8 characters'),
+  })
+  .refine(data => data.password === data.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  });
+
+export type CreateModeratorData = z.infer<typeof createModeratorSchema>;

--- a/src/lib/zod.ts
+++ b/src/lib/zod.ts
@@ -184,3 +184,15 @@ export const createModeratorSchema = z
   });
 
 export type CreateModeratorData = z.infer<typeof createModeratorSchema>;
+
+export const resetModeratorPasswordSchema = z
+  .object({
+    password: z.string().min(8, 'Password must be at least 8 characters'),
+    confirmPassword: z.string().min(8, 'Password must be at least 8 characters'),
+  })
+  .refine(data => data.password === data.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  });
+
+export type ResetModeratorPasswordData = z.infer<typeof resetModeratorPasswordSchema>;

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter, Navigate, Outlet, Route, Routes } from 'react-router';
 import { useEffect, useState, Suspense } from 'react';
-import { getCurrentSession, getMasjidMembership } from '@/lib/supabase';
+import { getCurrentSession, getMasjidMembership, updateLastActive } from '@/lib/supabase';
 import { subscribeToAuthChanges } from '@/lib/supabase';
 import { AppRoutes, AuthRoutes } from '@/constants';
 import { AppLayout } from '@/components/layout';
@@ -58,6 +58,7 @@ export default function Navigation() {
           try {
             const membership = await getMasjidMembership();
             setAuth(membership.masjid_id, membership.role);
+            updateLastActive();
           } catch {
             // User may not have membership yet (e.g. during registration)
           }

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -196,7 +196,14 @@ export default function Navigation() {
                 </RequireAdmin>
               }
             />
-            <Route path={AppRoutes.Support} element={<Support />} />
+            <Route
+              path={AppRoutes.Support}
+              element={
+                <RequireAdmin>
+                  <Support />
+                </RequireAdmin>
+              }
+            />
           </Route>
 
           {/* Display routes - require authentication */}

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Navigate, Outlet, Route, Routes } from 'react-router';
 import { useEffect, useState, Suspense } from 'react';
-import { getCurrentSession, subscribeToAuthChanges } from '@/lib/supabase';
+import { getCurrentSession, getMasjidMembership } from '@/lib/supabase';
+import { subscribeToAuthChanges } from '@/lib/supabase';
 import { AppRoutes, AuthRoutes } from '@/constants';
 import { AppLayout } from '@/components/layout';
 import {
@@ -11,6 +12,7 @@ import {
   Home,
   Loading,
   Login,
+  Moderators,
   Posts,
   Register,
   ResetPassword,
@@ -29,13 +31,20 @@ import {
   YouTubeVideos,
   Support,
 } from '@/pages';
-import { useDisplayStore } from '@/store';
+import { useDisplayStore, useAuthStore } from '@/store';
+
+function RequireAdmin({ children }: { children: React.ReactNode }) {
+  const role = useAuthStore(s => s.role);
+  if (role !== 'admin') return <Navigate to={AppRoutes.Home} />;
+  return <>{children}</>;
+}
 
 export default function Navigation() {
   const [isLoggedInWithEmail, setIsLoggedInWithEmail] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   const { loggedIn: isLoggedInWithCode } = useDisplayStore();
+  const { setAuth, clearAuth } = useAuthStore();
 
   const route = isLoggedInWithEmail ? AppRoutes.Home : AppRoutes.Display;
 
@@ -44,6 +53,15 @@ export default function Navigation() {
       try {
         const session = await getCurrentSession();
         setIsLoggedInWithEmail(!!session);
+
+        if (session?.user) {
+          try {
+            const membership = await getMasjidMembership();
+            setAuth(membership.masjid_id, membership.role);
+          } catch {
+            // User may not have membership yet (e.g. during registration)
+          }
+        }
       } catch (error) {
         console.error('Error checking authentication:', error);
       } finally {
@@ -55,8 +73,19 @@ export default function Navigation() {
 
     const {
       data: { subscription },
-    } = subscribeToAuthChanges(session => {
+    } = subscribeToAuthChanges(async session => {
       setIsLoggedInWithEmail(!!session?.user);
+
+      if (session?.user) {
+        try {
+          const membership = await getMasjidMembership();
+          setAuth(membership.masjid_id, membership.role);
+        } catch {
+          // User may not have membership yet
+        }
+      } else {
+        clearAuth();
+      }
     });
 
     return () => {
@@ -94,15 +123,78 @@ export default function Navigation() {
             <Route path={AppRoutes.Events} element={<Events />} />
             <Route path={AppRoutes.Posts} element={<Posts />} />
             <Route path={AppRoutes.YouTubeVideos} element={<YouTubeVideos />} />
-            <Route path={AppRoutes.Screens} element={<Screens />} />
-            <Route path={AppRoutes.ScreenDetail} element={<ScreenDetail />} />
-            <Route path={AppRoutes.PrayerTimings} element={<PrayerTimings />} />
-            <Route path={AppRoutes.Settings} element={<Settings />} />
-            <Route path={AppRoutes.SettingsProfile} element={<SettingsProfile />} />
-
-            <Route path={AppRoutes.SettingsThemes} element={<SettingsThemes />} />
-            <Route path={AppRoutes.SettingsHijri} element={<SettingsHijri />} />
-            <Route path={AppRoutes.SettingsPrayerTimes} element={<SettingsPrayerTimes />} />
+            <Route
+              path={AppRoutes.Screens}
+              element={
+                <RequireAdmin>
+                  <Screens />
+                </RequireAdmin>
+              }
+            />
+            <Route
+              path={AppRoutes.ScreenDetail}
+              element={
+                <RequireAdmin>
+                  <ScreenDetail />
+                </RequireAdmin>
+              }
+            />
+            <Route
+              path={AppRoutes.PrayerTimings}
+              element={
+                <RequireAdmin>
+                  <PrayerTimings />
+                </RequireAdmin>
+              }
+            />
+            <Route
+              path={AppRoutes.Settings}
+              element={
+                <RequireAdmin>
+                  <Settings />
+                </RequireAdmin>
+              }
+            />
+            <Route
+              path={AppRoutes.SettingsProfile}
+              element={
+                <RequireAdmin>
+                  <SettingsProfile />
+                </RequireAdmin>
+              }
+            />
+            <Route
+              path={AppRoutes.SettingsThemes}
+              element={
+                <RequireAdmin>
+                  <SettingsThemes />
+                </RequireAdmin>
+              }
+            />
+            <Route
+              path={AppRoutes.SettingsHijri}
+              element={
+                <RequireAdmin>
+                  <SettingsHijri />
+                </RequireAdmin>
+              }
+            />
+            <Route
+              path={AppRoutes.SettingsPrayerTimes}
+              element={
+                <RequireAdmin>
+                  <SettingsPrayerTimes />
+                </RequireAdmin>
+              }
+            />
+            <Route
+              path={AppRoutes.Moderators}
+              element={
+                <RequireAdmin>
+                  <Moderators />
+                </RequireAdmin>
+              }
+            />
             <Route path={AppRoutes.Support} element={<Support />} />
           </Route>
 

--- a/src/pages/app/home.tsx
+++ b/src/pages/app/home.tsx
@@ -1,16 +1,24 @@
 import { BookOpen, Bell, Clock, Settings, Images, Tickets, User } from 'lucide-react';
 import { AppRoutes } from '@/constants';
 import { ModuleCard, QuickActionButton, WelcomeHeader, SectionTitle } from '@/components/home';
+import { useAuthStore } from '@/store';
 
 export default function Home() {
+  const role = useAuthStore(s => s.role);
+  const isAdmin = role === 'admin';
+
   const modules = [
-    {
-      title: 'Prayer Timings',
-      description: 'Manage prayer times for your masjid',
-      icon: <Clock className='h-10 w-10 text-primary' />,
-      path: AppRoutes.PrayerTimings,
-      color: 'bg-red-50 dark:bg-red-950/30',
-    },
+    ...(isAdmin
+      ? [
+          {
+            title: 'Prayer Timings',
+            description: 'Manage prayer times for your masjid',
+            icon: <Clock className='h-10 w-10 text-primary' />,
+            path: AppRoutes.PrayerTimings,
+            color: 'bg-red-50 dark:bg-red-950/30',
+          },
+        ]
+      : []),
     {
       title: 'Ayat & Hadith',
       description: 'Manage your collection of Quranic verses and Hadith',
@@ -40,18 +48,22 @@ export default function Home() {
       icon: <Images className='h-5 w-5' />,
       path: AppRoutes.Posts,
     },
-    {
-      title: 'Update Profile',
-      description: 'Manage your masjid information',
-      icon: <User className='h-5 w-5' />,
-      path: AppRoutes.SettingsProfile,
-    },
-    {
-      title: 'Settings',
-      description: 'Update the display settings',
-      icon: <Settings className='h-5 w-5' />,
-      path: AppRoutes.Settings,
-    },
+    ...(isAdmin
+      ? [
+          {
+            title: 'Update Profile',
+            description: 'Manage your masjid information',
+            icon: <User className='h-5 w-5' />,
+            path: AppRoutes.SettingsProfile,
+          },
+          {
+            title: 'Settings',
+            description: 'Update the display settings',
+            icon: <Settings className='h-5 w-5' />,
+            path: AppRoutes.Settings,
+          },
+        ]
+      : []),
   ];
 
   return (

--- a/src/pages/app/index.ts
+++ b/src/pages/app/index.ts
@@ -19,4 +19,5 @@ export const ScreenDetail = lazy(() => import('./screen-detail'));
 export const Display = lazy(() => import('./display'));
 export const DisplayLogout = lazy(() => import('./display-logout'));
 export const YouTubeVideos = lazy(() => import('./youtube-videos'));
+export const Moderators = lazy(() => import('./moderators'));
 export const Support = lazy(() => import('./support'));

--- a/src/pages/app/moderators.tsx
+++ b/src/pages/app/moderators.tsx
@@ -1,9 +1,19 @@
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { getModerators, createModerator, revokeModerator } from '@/lib/supabase';
+import {
+  getModerators,
+  createModerator,
+  revokeModerator,
+  resetModeratorPassword,
+} from '@/lib/supabase';
 import type { ModeratorWithEmail } from '@/lib/supabase/services/moderators';
-import { createModeratorSchema, type CreateModeratorData } from '@/lib/zod';
+import {
+  createModeratorSchema,
+  type CreateModeratorData,
+  resetModeratorPasswordSchema,
+  type ResetModeratorPasswordData,
+} from '@/lib/zod';
 import { TableSkeleton } from '@/components/skeletons';
 import { PageHeader, ErrorAlert, EmptyState, DataTable, type Column } from '@/components/common';
 import {
@@ -17,7 +27,7 @@ import {
   Input,
   Label,
 } from '@/components/ui';
-import { Users, Trash2, Eye, EyeOff } from 'lucide-react';
+import { Users, Trash2, KeyRound, Eye, EyeOff } from 'lucide-react';
 import { useTrigger } from '@/hooks';
 import { toast } from 'sonner';
 import { formatDistanceToNow } from 'date-fns';
@@ -28,11 +38,16 @@ export default function Moderators() {
   const [error, setError] = useState<string | null>(null);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [isRevokeModalOpen, setIsRevokeModalOpen] = useState(false);
+  const [isResetPasswordModalOpen, setIsResetPasswordModalOpen] = useState(false);
   const [moderatorToRevoke, setModeratorToRevoke] = useState<ModeratorWithEmail | null>(null);
+  const [moderatorToReset, setModeratorToReset] = useState<ModeratorWithEmail | null>(null);
   const [isRevoking, setIsRevoking] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
+  const [isResetting, setIsResetting] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [showResetPassword, setShowResetPassword] = useState(false);
+  const [showResetConfirmPassword, setShowResetConfirmPassword] = useState(false);
 
   const [trigger, forceUpdate] = useTrigger();
 
@@ -43,6 +58,15 @@ export default function Moderators() {
     formState: { errors },
   } = useForm<CreateModeratorData>({
     resolver: zodResolver(createModeratorSchema),
+  });
+
+  const {
+    register: registerReset,
+    handleSubmit: handleSubmitReset,
+    reset: resetResetForm,
+    formState: { errors: resetErrors },
+  } = useForm<ResetModeratorPasswordData>({
+    resolver: zodResolver(resetModeratorPasswordSchema),
   });
 
   useEffect(() => {
@@ -118,6 +142,36 @@ export default function Moderators() {
     setModeratorToRevoke(null);
   };
 
+  const handleResetPasswordClick = (moderator: ModeratorWithEmail) => {
+    setModeratorToReset(moderator);
+    resetResetForm();
+    setShowResetPassword(false);
+    setShowResetConfirmPassword(false);
+    setIsResetPasswordModalOpen(true);
+  };
+
+  const handleResetPasswordClose = () => {
+    setIsResetPasswordModalOpen(false);
+    setModeratorToReset(null);
+    resetResetForm();
+  };
+
+  const onSubmitResetPassword = async (data: ResetModeratorPasswordData) => {
+    if (!moderatorToReset) return;
+
+    try {
+      setIsResetting(true);
+      await resetModeratorPassword(moderatorToReset.user_id, data.password);
+      toast.success('Password reset successfully');
+      handleResetPasswordClose();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to reset password';
+      toast.error(message);
+    } finally {
+      setIsResetting(false);
+    }
+  };
+
   const columns: Column<ModeratorWithEmail>[] = [
     {
       key: 'email',
@@ -179,15 +233,26 @@ export default function Moderators() {
           showRowNumbers={true}
           actionsWidth='w-[10%]'
           renderActions={item => (
-            <Button
-              variant='ghost'
-              size='icon'
-              className='text-destructive hover:text-destructive hover:bg-destructive/10'
-              onClick={() => handleRevokeClick(item)}
-              title='Revoke moderator'
-            >
-              <Trash2 size={16} />
-            </Button>
+            <div className='flex items-center gap-1'>
+              <Button
+                variant='ghost'
+                size='icon'
+                className='hover:bg-muted'
+                onClick={() => handleResetPasswordClick(item)}
+                title='Reset password'
+              >
+                <KeyRound size={16} />
+              </Button>
+              <Button
+                variant='ghost'
+                size='icon'
+                className='text-destructive hover:text-destructive hover:bg-destructive/10'
+                onClick={() => handleRevokeClick(item)}
+                title='Revoke moderator'
+              >
+                <Trash2 size={16} />
+              </Button>
+            </div>
           )}
         />
       )}
@@ -274,6 +339,83 @@ export default function Moderators() {
               </Button>
               <Button type='submit' disabled={isCreating} loading={isCreating}>
                 Create Moderator
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Reset Password Modal */}
+      <Dialog
+        open={isResetPasswordModalOpen}
+        onOpenChange={open => !open && handleResetPasswordClose()}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Reset Password</DialogTitle>
+            <DialogDescription>Set a new password for {moderatorToReset?.email}</DialogDescription>
+          </DialogHeader>
+
+          <form onSubmit={handleSubmitReset(onSubmitResetPassword)} className='space-y-4'>
+            <div className='space-y-2'>
+              <Label htmlFor='resetPassword'>New Password</Label>
+              <div className='relative'>
+                <Input
+                  id='resetPassword'
+                  type={showResetPassword ? 'text' : 'password'}
+                  placeholder='Minimum 8 characters'
+                  {...registerReset('password')}
+                />
+                <Button
+                  type='button'
+                  variant='ghost'
+                  size='icon'
+                  className='absolute right-0 top-0 h-full px-3 hover:bg-transparent'
+                  onClick={() => setShowResetPassword(!showResetPassword)}
+                >
+                  {showResetPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+                </Button>
+              </div>
+              {resetErrors.password && (
+                <p className='text-sm text-destructive'>{resetErrors.password.message}</p>
+              )}
+            </div>
+
+            <div className='space-y-2'>
+              <Label htmlFor='resetConfirmPassword'>Confirm New Password</Label>
+              <div className='relative'>
+                <Input
+                  id='resetConfirmPassword'
+                  type={showResetConfirmPassword ? 'text' : 'password'}
+                  placeholder='Confirm password'
+                  {...registerReset('confirmPassword')}
+                />
+                <Button
+                  type='button'
+                  variant='ghost'
+                  size='icon'
+                  className='absolute right-0 top-0 h-full px-3 hover:bg-transparent'
+                  onClick={() => setShowResetConfirmPassword(!showResetConfirmPassword)}
+                >
+                  {showResetConfirmPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+                </Button>
+              </div>
+              {resetErrors.confirmPassword && (
+                <p className='text-sm text-destructive'>{resetErrors.confirmPassword.message}</p>
+              )}
+            </div>
+
+            <DialogFooter>
+              <Button
+                type='button'
+                variant='outline'
+                onClick={handleResetPasswordClose}
+                disabled={isResetting}
+              >
+                Cancel
+              </Button>
+              <Button type='submit' disabled={isResetting} loading={isResetting}>
+                Reset Password
               </Button>
             </DialogFooter>
           </form>

--- a/src/pages/app/moderators.tsx
+++ b/src/pages/app/moderators.tsx
@@ -1,0 +1,317 @@
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { getModerators, createModerator, revokeModerator } from '@/lib/supabase';
+import type { ModeratorWithEmail } from '@/lib/supabase/services/moderators';
+import { createModeratorSchema, type CreateModeratorData } from '@/lib/zod';
+import { TableSkeleton } from '@/components/skeletons';
+import { PageHeader, ErrorAlert, EmptyState, DataTable, type Column } from '@/components/common';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Button,
+  Input,
+  Label,
+} from '@/components/ui';
+import { Users, Trash2, Eye, EyeOff } from 'lucide-react';
+import { useTrigger } from '@/hooks';
+import { toast } from 'sonner';
+import { formatDistanceToNow } from 'date-fns';
+
+export default function Moderators() {
+  const [moderators, setModerators] = useState<ModeratorWithEmail[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+  const [isRevokeModalOpen, setIsRevokeModalOpen] = useState(false);
+  const [moderatorToRevoke, setModeratorToRevoke] = useState<ModeratorWithEmail | null>(null);
+  const [isRevoking, setIsRevoking] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  const [trigger, forceUpdate] = useTrigger();
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<CreateModeratorData>({
+    resolver: zodResolver(createModeratorSchema),
+  });
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const data = await getModerators();
+        setModerators(data);
+      } catch (err) {
+        setError('Failed to fetch moderators');
+        toast.error('Failed to fetch moderators');
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [trigger]);
+
+  const handleAddNew = () => {
+    reset();
+    setShowPassword(false);
+    setShowConfirmPassword(false);
+    setIsAddModalOpen(true);
+  };
+
+  const handleAddModalClose = () => {
+    setIsAddModalOpen(false);
+    reset();
+  };
+
+  const onSubmitCreate = async (data: CreateModeratorData) => {
+    try {
+      setIsCreating(true);
+      await createModerator(data.email, data.password);
+      toast.success('Moderator created successfully');
+      handleAddModalClose();
+      forceUpdate();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to create moderator';
+      toast.error(message);
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleRevokeClick = (moderator: ModeratorWithEmail) => {
+    setModeratorToRevoke(moderator);
+    setIsRevokeModalOpen(true);
+  };
+
+  const handleRevokeConfirm = async () => {
+    if (!moderatorToRevoke) return;
+
+    try {
+      setIsRevoking(true);
+      await revokeModerator(moderatorToRevoke.user_id);
+      toast.success('Moderator revoked successfully');
+      setIsRevokeModalOpen(false);
+      setModeratorToRevoke(null);
+      forceUpdate();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to revoke moderator';
+      toast.error(message);
+    } finally {
+      setIsRevoking(false);
+    }
+  };
+
+  const handleRevokeCancel = () => {
+    setIsRevokeModalOpen(false);
+    setModeratorToRevoke(null);
+  };
+
+  const columns: Column<ModeratorWithEmail>[] = [
+    {
+      key: 'email',
+      name: 'Email',
+      width: 'w-[40%]',
+      render: value => <span className='font-medium'>{value as string}</span>,
+    },
+    {
+      key: 'last_active_at',
+      name: 'Last Active',
+      width: 'w-[25%]',
+      render: value =>
+        value ? (
+          <span className='text-muted-foreground'>
+            {formatDistanceToNow(new Date(value as string), { addSuffix: true })}
+          </span>
+        ) : (
+          <span className='text-muted-foreground italic'>Never</span>
+        ),
+    },
+    {
+      key: 'created_at',
+      name: 'Added',
+      width: 'w-[25%]',
+      render: value => (
+        <span className='text-muted-foreground'>
+          {formatDistanceToNow(new Date(value as string), { addSuffix: true })}
+        </span>
+      ),
+    },
+  ];
+
+  return (
+    <div className='container mx-auto py-8 space-y-6'>
+      <PageHeader
+        title='Moderators'
+        description='Manage moderators who can help manage your masjid content'
+        addButtonText='Add Moderator'
+        onAddClick={handleAddNew}
+      />
+
+      <ErrorAlert message={error} onClose={() => setError(null)} />
+
+      {loading ? (
+        <TableSkeleton columns={columns} showRowNumbers={true} />
+      ) : moderators.length === 0 ? (
+        <EmptyState
+          icon={<Users className='h-6 w-6 text-muted-foreground' />}
+          title='No moderators yet'
+          description='Add moderators to help manage your masjid content. Moderators can manage ayat, announcements, events, posts, and videos.'
+          actionText='Add First Moderator'
+          onActionClick={handleAddNew}
+        />
+      ) : (
+        <DataTable
+          columns={columns}
+          data={moderators}
+          keyField='id'
+          showRowNumbers={true}
+          actionsWidth='w-[10%]'
+          renderActions={item => (
+            <Button
+              variant='ghost'
+              size='icon'
+              className='text-destructive hover:text-destructive hover:bg-destructive/10'
+              onClick={() => handleRevokeClick(item)}
+              title='Revoke moderator'
+            >
+              <Trash2 size={16} />
+            </Button>
+          )}
+        />
+      )}
+
+      {/* Add Moderator Modal */}
+      <Dialog open={isAddModalOpen} onOpenChange={open => !open && handleAddModalClose()}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add Moderator</DialogTitle>
+            <DialogDescription>
+              Create an account for a new moderator. They will be able to manage content but not
+              settings, screens, or prayer times.
+            </DialogDescription>
+          </DialogHeader>
+
+          <form onSubmit={handleSubmit(onSubmitCreate)} className='space-y-4'>
+            <div className='space-y-2'>
+              <Label htmlFor='email'>Email</Label>
+              <Input
+                id='email'
+                type='email'
+                placeholder='moderator@example.com'
+                {...register('email')}
+              />
+              {errors.email && <p className='text-sm text-destructive'>{errors.email.message}</p>}
+            </div>
+
+            <div className='space-y-2'>
+              <Label htmlFor='password'>Password</Label>
+              <div className='relative'>
+                <Input
+                  id='password'
+                  type={showPassword ? 'text' : 'password'}
+                  placeholder='Minimum 8 characters'
+                  {...register('password')}
+                />
+                <Button
+                  type='button'
+                  variant='ghost'
+                  size='icon'
+                  className='absolute right-0 top-0 h-full px-3 hover:bg-transparent'
+                  onClick={() => setShowPassword(!showPassword)}
+                >
+                  {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+                </Button>
+              </div>
+              {errors.password && (
+                <p className='text-sm text-destructive'>{errors.password.message}</p>
+              )}
+            </div>
+
+            <div className='space-y-2'>
+              <Label htmlFor='confirmPassword'>Confirm Password</Label>
+              <div className='relative'>
+                <Input
+                  id='confirmPassword'
+                  type={showConfirmPassword ? 'text' : 'password'}
+                  placeholder='Confirm password'
+                  {...register('confirmPassword')}
+                />
+                <Button
+                  type='button'
+                  variant='ghost'
+                  size='icon'
+                  className='absolute right-0 top-0 h-full px-3 hover:bg-transparent'
+                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                >
+                  {showConfirmPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+                </Button>
+              </div>
+              {errors.confirmPassword && (
+                <p className='text-sm text-destructive'>{errors.confirmPassword.message}</p>
+              )}
+            </div>
+
+            <DialogFooter>
+              <Button
+                type='button'
+                variant='outline'
+                onClick={handleAddModalClose}
+                disabled={isCreating}
+              >
+                Cancel
+              </Button>
+              <Button type='submit' disabled={isCreating} loading={isCreating}>
+                Create Moderator
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Revoke Confirmation Modal */}
+      <Dialog open={isRevokeModalOpen} onOpenChange={open => !open && handleRevokeCancel()}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Revoke Moderator</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to revoke this moderator? They will lose access immediately and
+              their account will be deleted.
+            </DialogDescription>
+          </DialogHeader>
+
+          {moderatorToRevoke && (
+            <div className='mt-2 p-4 bg-muted rounded border'>
+              <p className='font-medium text-foreground'>{moderatorToRevoke.email}</p>
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button variant='outline' onClick={handleRevokeCancel} disabled={isRevoking}>
+              Cancel
+            </Button>
+            <Button
+              variant='destructive'
+              onClick={handleRevokeConfirm}
+              disabled={isRevoking}
+              loading={isRevoking}
+            >
+              Revoke Access
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/app/moderators.tsx
+++ b/src/pages/app/moderators.tsx
@@ -6,6 +6,7 @@ import {
   createModerator,
   revokeModerator,
   resetModeratorPassword,
+  updateModerator,
 } from '@/lib/supabase';
 import type { ModeratorWithEmail } from '@/lib/supabase/services/moderators';
 import {
@@ -13,6 +14,8 @@ import {
   type CreateModeratorData,
   resetModeratorPasswordSchema,
   type ResetModeratorPasswordData,
+  updateModeratorSchema,
+  type UpdateModeratorData,
 } from '@/lib/zod';
 import { TableSkeleton } from '@/components/skeletons';
 import { PageHeader, ErrorAlert, EmptyState, DataTable, type Column } from '@/components/common';
@@ -27,7 +30,7 @@ import {
   Input,
   Label,
 } from '@/components/ui';
-import { Users, Trash2, KeyRound, Eye, EyeOff } from 'lucide-react';
+import { Users, Trash2, KeyRound, Pencil, Eye, EyeOff } from 'lucide-react';
 import { useTrigger } from '@/hooks';
 import { toast } from 'sonner';
 import { formatDistanceToNow } from 'date-fns';
@@ -39,11 +42,14 @@ export default function Moderators() {
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [isRevokeModalOpen, setIsRevokeModalOpen] = useState(false);
   const [isResetPasswordModalOpen, setIsResetPasswordModalOpen] = useState(false);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [moderatorToRevoke, setModeratorToRevoke] = useState<ModeratorWithEmail | null>(null);
   const [moderatorToReset, setModeratorToReset] = useState<ModeratorWithEmail | null>(null);
+  const [moderatorToEdit, setModeratorToEdit] = useState<ModeratorWithEmail | null>(null);
   const [isRevoking, setIsRevoking] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
   const [isResetting, setIsResetting] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [showResetPassword, setShowResetPassword] = useState(false);
@@ -51,22 +57,16 @@ export default function Moderators() {
 
   const [trigger, forceUpdate] = useTrigger();
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    formState: { errors },
-  } = useForm<CreateModeratorData>({
+  const createForm = useForm<CreateModeratorData>({
     resolver: zodResolver(createModeratorSchema),
   });
 
-  const {
-    register: registerReset,
-    handleSubmit: handleSubmitReset,
-    reset: resetResetForm,
-    formState: { errors: resetErrors },
-  } = useForm<ResetModeratorPasswordData>({
+  const resetPasswordForm = useForm<ResetModeratorPasswordData>({
     resolver: zodResolver(resetModeratorPasswordSchema),
+  });
+
+  const editForm = useForm<UpdateModeratorData>({
+    resolver: zodResolver(updateModeratorSchema),
   });
 
   useEffect(() => {
@@ -87,8 +87,9 @@ export default function Moderators() {
     fetchData();
   }, [trigger]);
 
+  // Add modal
   const handleAddNew = () => {
-    reset();
+    createForm.reset();
     setShowPassword(false);
     setShowConfirmPassword(false);
     setIsAddModalOpen(true);
@@ -96,13 +97,13 @@ export default function Moderators() {
 
   const handleAddModalClose = () => {
     setIsAddModalOpen(false);
-    reset();
+    createForm.reset();
   };
 
   const onSubmitCreate = async (data: CreateModeratorData) => {
     try {
       setIsCreating(true);
-      await createModerator(data.email, data.password);
+      await createModerator(data.email, data.password, data.name);
       toast.success('Moderator created successfully');
       handleAddModalClose();
       forceUpdate();
@@ -114,6 +115,7 @@ export default function Moderators() {
     }
   };
 
+  // Revoke modal
   const handleRevokeClick = (moderator: ModeratorWithEmail) => {
     setModeratorToRevoke(moderator);
     setIsRevokeModalOpen(true);
@@ -121,7 +123,6 @@ export default function Moderators() {
 
   const handleRevokeConfirm = async () => {
     if (!moderatorToRevoke) return;
-
     try {
       setIsRevoking(true);
       await revokeModerator(moderatorToRevoke.user_id);
@@ -142,9 +143,10 @@ export default function Moderators() {
     setModeratorToRevoke(null);
   };
 
+  // Reset password modal
   const handleResetPasswordClick = (moderator: ModeratorWithEmail) => {
     setModeratorToReset(moderator);
-    resetResetForm();
+    resetPasswordForm.reset();
     setShowResetPassword(false);
     setShowResetConfirmPassword(false);
     setIsResetPasswordModalOpen(true);
@@ -153,12 +155,11 @@ export default function Moderators() {
   const handleResetPasswordClose = () => {
     setIsResetPasswordModalOpen(false);
     setModeratorToReset(null);
-    resetResetForm();
+    resetPasswordForm.reset();
   };
 
   const onSubmitResetPassword = async (data: ResetModeratorPasswordData) => {
     if (!moderatorToReset) return;
-
     try {
       setIsResetting(true);
       await resetModeratorPassword(moderatorToReset.user_id, data.password);
@@ -172,17 +173,66 @@ export default function Moderators() {
     }
   };
 
+  // Edit modal
+  const handleEditClick = (moderator: ModeratorWithEmail) => {
+    setModeratorToEdit(moderator);
+    editForm.reset({ name: moderator.name, email: moderator.email });
+    setIsEditModalOpen(true);
+  };
+
+  const handleEditClose = () => {
+    setIsEditModalOpen(false);
+    setModeratorToEdit(null);
+    editForm.reset();
+  };
+
+  const onSubmitEdit = async (data: UpdateModeratorData) => {
+    if (!moderatorToEdit) return;
+    try {
+      setIsUpdating(true);
+      const updates: { name?: string; email?: string } = {};
+      if (data.name !== moderatorToEdit.name) updates.name = data.name;
+      if (data.email !== moderatorToEdit.email) updates.email = data.email;
+
+      if (Object.keys(updates).length === 0) {
+        handleEditClose();
+        return;
+      }
+
+      await updateModerator(moderatorToEdit.user_id, updates);
+      toast.success('Moderator updated successfully');
+      handleEditClose();
+      forceUpdate();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update moderator';
+      toast.error(message);
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
   const columns: Column<ModeratorWithEmail>[] = [
+    {
+      key: 'name',
+      name: 'Name',
+      width: 'w-[25%]',
+      render: value =>
+        value ? (
+          <span className='font-medium'>{value as string}</span>
+        ) : (
+          <span className='text-muted-foreground italic'>—</span>
+        ),
+    },
     {
       key: 'email',
       name: 'Email',
-      width: 'w-[40%]',
-      render: value => <span className='font-medium'>{value as string}</span>,
+      width: 'w-[30%]',
+      render: value => <span>{value as string}</span>,
     },
     {
       key: 'last_active_at',
       name: 'Last Active',
-      width: 'w-[25%]',
+      width: 'w-[20%]',
       render: value =>
         value ? (
           <span className='text-muted-foreground'>
@@ -195,7 +245,7 @@ export default function Moderators() {
     {
       key: 'created_at',
       name: 'Added',
-      width: 'w-[25%]',
+      width: 'w-[15%]',
       render: value => (
         <span className='text-muted-foreground'>
           {formatDistanceToNow(new Date(value as string), { addSuffix: true })}
@@ -238,6 +288,15 @@ export default function Moderators() {
                 variant='ghost'
                 size='icon'
                 className='hover:bg-muted'
+                onClick={() => handleEditClick(item)}
+                title='Edit moderator'
+              >
+                <Pencil size={16} />
+              </Button>
+              <Button
+                variant='ghost'
+                size='icon'
+                className='hover:bg-muted'
                 onClick={() => handleResetPasswordClick(item)}
                 title='Reset password'
               >
@@ -268,16 +327,30 @@ export default function Moderators() {
             </DialogDescription>
           </DialogHeader>
 
-          <form onSubmit={handleSubmit(onSubmitCreate)} className='space-y-4'>
+          <form onSubmit={createForm.handleSubmit(onSubmitCreate)} className='space-y-4'>
+            <div className='space-y-2'>
+              <Label htmlFor='name'>Name</Label>
+              <Input id='name' placeholder='Full name' {...createForm.register('name')} />
+              {createForm.formState.errors.name && (
+                <p className='text-sm text-destructive'>
+                  {createForm.formState.errors.name.message}
+                </p>
+              )}
+            </div>
+
             <div className='space-y-2'>
               <Label htmlFor='email'>Email</Label>
               <Input
                 id='email'
                 type='email'
                 placeholder='moderator@example.com'
-                {...register('email')}
+                {...createForm.register('email')}
               />
-              {errors.email && <p className='text-sm text-destructive'>{errors.email.message}</p>}
+              {createForm.formState.errors.email && (
+                <p className='text-sm text-destructive'>
+                  {createForm.formState.errors.email.message}
+                </p>
+              )}
             </div>
 
             <div className='space-y-2'>
@@ -287,7 +360,7 @@ export default function Moderators() {
                   id='password'
                   type={showPassword ? 'text' : 'password'}
                   placeholder='Minimum 8 characters'
-                  {...register('password')}
+                  {...createForm.register('password')}
                 />
                 <Button
                   type='button'
@@ -299,8 +372,10 @@ export default function Moderators() {
                   {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
                 </Button>
               </div>
-              {errors.password && (
-                <p className='text-sm text-destructive'>{errors.password.message}</p>
+              {createForm.formState.errors.password && (
+                <p className='text-sm text-destructive'>
+                  {createForm.formState.errors.password.message}
+                </p>
               )}
             </div>
 
@@ -311,7 +386,7 @@ export default function Moderators() {
                   id='confirmPassword'
                   type={showConfirmPassword ? 'text' : 'password'}
                   placeholder='Confirm password'
-                  {...register('confirmPassword')}
+                  {...createForm.register('confirmPassword')}
                 />
                 <Button
                   type='button'
@@ -323,8 +398,10 @@ export default function Moderators() {
                   {showConfirmPassword ? <EyeOff size={16} /> : <Eye size={16} />}
                 </Button>
               </div>
-              {errors.confirmPassword && (
-                <p className='text-sm text-destructive'>{errors.confirmPassword.message}</p>
+              {createForm.formState.errors.confirmPassword && (
+                <p className='text-sm text-destructive'>
+                  {createForm.formState.errors.confirmPassword.message}
+                </p>
               )}
             </div>
 
@@ -345,6 +422,55 @@ export default function Moderators() {
         </DialogContent>
       </Dialog>
 
+      {/* Edit Moderator Modal */}
+      <Dialog open={isEditModalOpen} onOpenChange={open => !open && handleEditClose()}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Moderator</DialogTitle>
+            <DialogDescription>Update the moderator's name or email address.</DialogDescription>
+          </DialogHeader>
+
+          <form onSubmit={editForm.handleSubmit(onSubmitEdit)} className='space-y-4'>
+            <div className='space-y-2'>
+              <Label htmlFor='editName'>Name</Label>
+              <Input id='editName' placeholder='Full name' {...editForm.register('name')} />
+              {editForm.formState.errors.name && (
+                <p className='text-sm text-destructive'>{editForm.formState.errors.name.message}</p>
+              )}
+            </div>
+
+            <div className='space-y-2'>
+              <Label htmlFor='editEmail'>Email</Label>
+              <Input
+                id='editEmail'
+                type='email'
+                placeholder='moderator@example.com'
+                {...editForm.register('email')}
+              />
+              {editForm.formState.errors.email && (
+                <p className='text-sm text-destructive'>
+                  {editForm.formState.errors.email.message}
+                </p>
+              )}
+            </div>
+
+            <DialogFooter>
+              <Button
+                type='button'
+                variant='outline'
+                onClick={handleEditClose}
+                disabled={isUpdating}
+              >
+                Cancel
+              </Button>
+              <Button type='submit' disabled={isUpdating} loading={isUpdating}>
+                Save Changes
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
       {/* Reset Password Modal */}
       <Dialog
         open={isResetPasswordModalOpen}
@@ -353,10 +479,15 @@ export default function Moderators() {
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Reset Password</DialogTitle>
-            <DialogDescription>Set a new password for {moderatorToReset?.email}</DialogDescription>
+            <DialogDescription>
+              Set a new password for {moderatorToReset?.name || moderatorToReset?.email}
+            </DialogDescription>
           </DialogHeader>
 
-          <form onSubmit={handleSubmitReset(onSubmitResetPassword)} className='space-y-4'>
+          <form
+            onSubmit={resetPasswordForm.handleSubmit(onSubmitResetPassword)}
+            className='space-y-4'
+          >
             <div className='space-y-2'>
               <Label htmlFor='resetPassword'>New Password</Label>
               <div className='relative'>
@@ -364,7 +495,7 @@ export default function Moderators() {
                   id='resetPassword'
                   type={showResetPassword ? 'text' : 'password'}
                   placeholder='Minimum 8 characters'
-                  {...registerReset('password')}
+                  {...resetPasswordForm.register('password')}
                 />
                 <Button
                   type='button'
@@ -376,8 +507,10 @@ export default function Moderators() {
                   {showResetPassword ? <EyeOff size={16} /> : <Eye size={16} />}
                 </Button>
               </div>
-              {resetErrors.password && (
-                <p className='text-sm text-destructive'>{resetErrors.password.message}</p>
+              {resetPasswordForm.formState.errors.password && (
+                <p className='text-sm text-destructive'>
+                  {resetPasswordForm.formState.errors.password.message}
+                </p>
               )}
             </div>
 
@@ -388,7 +521,7 @@ export default function Moderators() {
                   id='resetConfirmPassword'
                   type={showResetConfirmPassword ? 'text' : 'password'}
                   placeholder='Confirm password'
-                  {...registerReset('confirmPassword')}
+                  {...resetPasswordForm.register('confirmPassword')}
                 />
                 <Button
                   type='button'
@@ -400,8 +533,10 @@ export default function Moderators() {
                   {showResetConfirmPassword ? <EyeOff size={16} /> : <Eye size={16} />}
                 </Button>
               </div>
-              {resetErrors.confirmPassword && (
-                <p className='text-sm text-destructive'>{resetErrors.confirmPassword.message}</p>
+              {resetPasswordForm.formState.errors.confirmPassword && (
+                <p className='text-sm text-destructive'>
+                  {resetPasswordForm.formState.errors.confirmPassword.message}
+                </p>
               )}
             </div>
 
@@ -435,7 +570,10 @@ export default function Moderators() {
 
           {moderatorToRevoke && (
             <div className='mt-2 p-4 bg-muted rounded border'>
-              <p className='font-medium text-foreground'>{moderatorToRevoke.email}</p>
+              {moderatorToRevoke.name && (
+                <p className='font-medium text-foreground'>{moderatorToRevoke.name}</p>
+              )}
+              <p className='text-sm text-muted-foreground'>{moderatorToRevoke.email}</p>
             </div>
           )}
 

--- a/src/pages/auth/login-with-code.tsx
+++ b/src/pages/auth/login-with-code.tsx
@@ -5,7 +5,7 @@ import { Button, Input, Label, ErrorBox } from '@/components/ui';
 import { cn } from '@/utils';
 import { loginWithCodeSchema, type LoginWithCodeData } from '@/lib/zod';
 import { Link, useSearchParams } from 'react-router';
-import { getScreenByCode, getMasjidProfileByUserId } from '@/lib/supabase';
+import { getScreenByCode, getMasjidProfileByMasjidId } from '@/lib/supabase';
 import { AuthRoutes } from '@/constants';
 import { useDisplayStore } from '@/store';
 
@@ -39,7 +39,7 @@ export default function LoginWithCode() {
           return;
         }
 
-        const masjidProfile = await getMasjidProfileByUserId(screen.user_id);
+        const masjidProfile = await getMasjidProfileByMasjidId(screen.masjid_id);
 
         setDisplayScreen(screen);
         setMasjidProfile(masjidProfile);

--- a/src/store/auth-store.ts
+++ b/src/store/auth-store.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import type { AuthStore } from '@/types';
+
+enum StorageKeys {
+  Auth = 'auth',
+}
+
+export const useAuthStore = create<AuthStore>()(
+  persist(
+    set => ({
+      masjidId: null,
+      role: null,
+      setAuth: (masjidId, role) => set({ masjidId, role }),
+      clearAuth: () => set({ masjidId: null, role: null }),
+    }),
+    { name: StorageKeys.Auth, storage: createJSONStorage(() => localStorage) }
+  )
+);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,6 +2,8 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import type { DisplayStore } from '@/types';
 
+export { useAuthStore } from './auth-store';
+
 enum StorageKeys {
   Display = 'display',
 }

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -1,4 +1,4 @@
-import type { DisplayScreen, MasjidProfile } from './supabase';
+import type { DisplayScreen, MasjidProfile, MemberRole } from './supabase';
 
 export type DisplayStore = {
   loggedIn: boolean;
@@ -8,4 +8,11 @@ export type DisplayStore = {
   displayScreen: DisplayScreen | null;
   setDisplayScreen: (displayScreen: DisplayScreen | null) => void;
   signOut: () => void;
+};
+
+export type AuthStore = {
+  masjidId: string | null;
+  role: MemberRole | null;
+  setAuth: (masjidId: string, role: MemberRole) => void;
+  clearAuth: () => void;
 };

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -12,6 +12,7 @@ export enum SupabaseTables {
   Settings = 'settings',
   DisplayScreens = 'display_screens',
   ScreenContent = 'screen_content',
+  MasjidMembers = 'masjid_members',
 }
 
 export enum SupabaseBuckets {
@@ -24,9 +25,22 @@ export enum SupabaseFolders {
   PredesignedPosts = 'predesigned-posts',
 }
 
+export type MemberRole = 'admin' | 'moderator';
+
+export interface MasjidMember {
+  id: string;
+  masjid_id: string;
+  user_id: string;
+  role: MemberRole;
+  last_active_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 interface Base {
   id: string;
   user_id: string;
+  masjid_id: string;
   created_at: string;
   updated_at: string;
 }

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -32,6 +32,7 @@ export interface MasjidMember {
   masjid_id: string;
   user_id: string;
   role: MemberRole;
+  name: string;
   last_active_at: string | null;
   created_at: string;
   updated_at: string;

--- a/supabase/functions/create-moderator/index.ts
+++ b/supabase/functions/create-moderator/index.ts
@@ -1,0 +1,105 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+Deno.serve(async req => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseAdmin = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    );
+
+    // Verify the calling user
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: 'Missing authorization header' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const {
+      data: { user: caller },
+    } = await supabaseAdmin.auth.getUser(authHeader.replace('Bearer ', ''));
+
+    if (!caller) {
+      return new Response(JSON.stringify({ error: 'Invalid token' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { email, password } = await req.json();
+
+    if (!email || !password) {
+      return new Response(JSON.stringify({ error: 'Email and password are required' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Verify caller is an admin
+    const { data: membership, error: membershipError } = await supabaseAdmin
+      .from('masjid_members')
+      .select('masjid_id, role')
+      .eq('user_id', caller.id)
+      .single();
+
+    if (membershipError || !membership || membership.role !== 'admin') {
+      return new Response(JSON.stringify({ error: 'Only admins can create moderators' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Create the auth user
+    const { data: newUser, error: createError } = await supabaseAdmin.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+    });
+
+    if (createError) {
+      return new Response(JSON.stringify({ error: createError.message }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Create the membership record
+    const { error: insertError } = await supabaseAdmin.from('masjid_members').insert({
+      masjid_id: membership.masjid_id,
+      user_id: newUser.user.id,
+      role: 'moderator',
+    });
+
+    if (insertError) {
+      // Rollback: delete the created user
+      await supabaseAdmin.auth.admin.deleteUser(newUser.user.id);
+      return new Response(JSON.stringify({ error: insertError.message }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(
+      JSON.stringify({ success: true, user_id: newUser.user.id, email: newUser.user.email }),
+      {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      }
+    );
+  } catch (error) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/functions/create-moderator/index.ts
+++ b/supabase/functions/create-moderator/index.ts
@@ -36,7 +36,7 @@ Deno.serve(async req => {
       });
     }
 
-    const { email, password } = await req.json();
+    const { email, password, name } = await req.json();
 
     if (!email || !password) {
       return new Response(JSON.stringify({ error: 'Email and password are required' }), {
@@ -78,6 +78,7 @@ Deno.serve(async req => {
       masjid_id: membership.masjid_id,
       user_id: newUser.user.id,
       role: 'moderator',
+      name: name || '',
     });
 
     if (insertError) {

--- a/supabase/functions/get-moderators/index.ts
+++ b/supabase/functions/get-moderators/index.ts
@@ -1,0 +1,88 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+Deno.serve(async req => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseAdmin = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    );
+
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: 'Missing authorization header' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const {
+      data: { user: caller },
+    } = await supabaseAdmin.auth.getUser(authHeader.replace('Bearer ', ''));
+
+    if (!caller) {
+      return new Response(JSON.stringify({ error: 'Invalid token' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Get caller's membership
+    const { data: membership, error: membershipError } = await supabaseAdmin
+      .from('masjid_members')
+      .select('masjid_id, role')
+      .eq('user_id', caller.id)
+      .single();
+
+    if (membershipError || !membership || membership.role !== 'admin') {
+      return new Response(JSON.stringify({ error: 'Only admins can view moderators' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Get all moderators for this masjid
+    const { data: members, error: membersError } = await supabaseAdmin
+      .from('masjid_members')
+      .select('*')
+      .eq('masjid_id', membership.masjid_id)
+      .eq('role', 'moderator')
+      .order('created_at', { ascending: false });
+
+    if (membersError) {
+      return new Response(JSON.stringify({ error: membersError.message }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Enrich with email from auth.users
+    const enrichedMembers = await Promise.all(
+      (members || []).map(async member => {
+        const { data: userData } = await supabaseAdmin.auth.admin.getUserById(member.user_id);
+        return {
+          ...member,
+          email: userData?.user?.email || 'Unknown',
+        };
+      })
+    );
+
+    return new Response(JSON.stringify(enrichedMembers), {
+      status: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/functions/reset-moderator-password/index.ts
+++ b/supabase/functions/reset-moderator-password/index.ts
@@ -1,0 +1,111 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+Deno.serve(async req => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseAdmin = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    );
+
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: 'Missing authorization header' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const {
+      data: { user: caller },
+    } = await supabaseAdmin.auth.getUser(authHeader.replace('Bearer ', ''));
+
+    if (!caller) {
+      return new Response(JSON.stringify({ error: 'Invalid token' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { user_id, password } = await req.json();
+
+    if (!user_id || !password) {
+      return new Response(JSON.stringify({ error: 'user_id and password are required' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Verify caller is an admin
+    const { data: callerMembership, error: callerError } = await supabaseAdmin
+      .from('masjid_members')
+      .select('masjid_id, role')
+      .eq('user_id', caller.id)
+      .single();
+
+    if (callerError || !callerMembership || callerMembership.role !== 'admin') {
+      return new Response(JSON.stringify({ error: 'Only admins can reset moderator passwords' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Verify the target user is a moderator in the same masjid
+    const { data: targetMembership, error: targetError } = await supabaseAdmin
+      .from('masjid_members')
+      .select('masjid_id, role')
+      .eq('user_id', user_id)
+      .single();
+
+    if (targetError || !targetMembership) {
+      return new Response(JSON.stringify({ error: 'Moderator not found' }), {
+        status: 404,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (targetMembership.masjid_id !== callerMembership.masjid_id) {
+      return new Response(JSON.stringify({ error: 'Moderator does not belong to your masjid' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (targetMembership.role === 'admin') {
+      return new Response(JSON.stringify({ error: 'Cannot reset an admin password' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Reset the password
+    const { error: updateError } = await supabaseAdmin.auth.admin.updateUserById(user_id, {
+      password,
+    });
+
+    if (updateError) {
+      return new Response(JSON.stringify({ error: updateError.message }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/functions/revoke-moderator/index.ts
+++ b/supabase/functions/revoke-moderator/index.ts
@@ -1,0 +1,124 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+Deno.serve(async req => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseAdmin = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    );
+
+    // Verify the calling user
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: 'Missing authorization header' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const {
+      data: { user: caller },
+    } = await supabaseAdmin.auth.getUser(authHeader.replace('Bearer ', ''));
+
+    if (!caller) {
+      return new Response(JSON.stringify({ error: 'Invalid token' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { user_id } = await req.json();
+
+    if (!user_id) {
+      return new Response(JSON.stringify({ error: 'user_id is required' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Verify caller is an admin
+    const { data: callerMembership, error: callerError } = await supabaseAdmin
+      .from('masjid_members')
+      .select('masjid_id, role')
+      .eq('user_id', caller.id)
+      .single();
+
+    if (callerError || !callerMembership || callerMembership.role !== 'admin') {
+      return new Response(JSON.stringify({ error: 'Only admins can revoke moderators' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Verify the target user is a moderator in the same masjid
+    const { data: targetMembership, error: targetError } = await supabaseAdmin
+      .from('masjid_members')
+      .select('masjid_id, role')
+      .eq('user_id', user_id)
+      .single();
+
+    if (targetError || !targetMembership) {
+      return new Response(JSON.stringify({ error: 'Moderator not found' }), {
+        status: 404,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (targetMembership.masjid_id !== callerMembership.masjid_id) {
+      return new Response(JSON.stringify({ error: 'Moderator does not belong to your masjid' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (targetMembership.role === 'admin') {
+      return new Response(JSON.stringify({ error: 'Cannot revoke an admin' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Delete the membership record
+    const { error: deleteError } = await supabaseAdmin
+      .from('masjid_members')
+      .delete()
+      .eq('user_id', user_id)
+      .eq('masjid_id', callerMembership.masjid_id);
+
+    if (deleteError) {
+      return new Response(JSON.stringify({ error: deleteError.message }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Delete the auth user entirely (invalidates all sessions immediately)
+    const { error: authDeleteError } = await supabaseAdmin.auth.admin.deleteUser(user_id);
+
+    if (authDeleteError) {
+      return new Response(JSON.stringify({ error: authDeleteError.message }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/functions/update-moderator/index.ts
+++ b/supabase/functions/update-moderator/index.ts
@@ -1,0 +1,130 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+Deno.serve(async req => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseAdmin = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    );
+
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: 'Missing authorization header' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const {
+      data: { user: caller },
+    } = await supabaseAdmin.auth.getUser(authHeader.replace('Bearer ', ''));
+
+    if (!caller) {
+      return new Response(JSON.stringify({ error: 'Invalid token' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { user_id, name, email } = await req.json();
+
+    if (!user_id) {
+      return new Response(JSON.stringify({ error: 'user_id is required' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Verify caller is an admin
+    const { data: callerMembership, error: callerError } = await supabaseAdmin
+      .from('masjid_members')
+      .select('masjid_id, role')
+      .eq('user_id', caller.id)
+      .single();
+
+    if (callerError || !callerMembership || callerMembership.role !== 'admin') {
+      return new Response(JSON.stringify({ error: 'Only admins can update moderators' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Verify the target user is a moderator in the same masjid
+    const { data: targetMembership, error: targetError } = await supabaseAdmin
+      .from('masjid_members')
+      .select('masjid_id, role')
+      .eq('user_id', user_id)
+      .single();
+
+    if (targetError || !targetMembership) {
+      return new Response(JSON.stringify({ error: 'Moderator not found' }), {
+        status: 404,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (targetMembership.masjid_id !== callerMembership.masjid_id) {
+      return new Response(JSON.stringify({ error: 'Moderator does not belong to your masjid' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (targetMembership.role === 'admin') {
+      return new Response(JSON.stringify({ error: 'Cannot update an admin' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Update name in masjid_members
+    if (name !== undefined) {
+      const { error: nameError } = await supabaseAdmin
+        .from('masjid_members')
+        .update({ name, updated_at: new Date().toISOString() })
+        .eq('user_id', user_id)
+        .eq('masjid_id', callerMembership.masjid_id);
+
+      if (nameError) {
+        return new Response(JSON.stringify({ error: nameError.message }), {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+    }
+
+    // Update email in auth.users
+    if (email) {
+      const { error: emailError } = await supabaseAdmin.auth.admin.updateUserById(user_id, {
+        email,
+        email_confirm: true,
+      });
+
+      if (emailError) {
+        return new Response(JSON.stringify({ error: emailError.message }), {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+    }
+
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/migrations/20260408000001_add_moderator_support.sql
+++ b/supabase/migrations/20260408000001_add_moderator_support.sql
@@ -1,0 +1,135 @@
+-- ============================================
+-- Moderator support: masjid_members table,
+-- masjid_id columns, backfill, helper functions,
+-- and activity tracking triggers.
+-- ============================================
+
+-- ============================================
+-- 1. Create masjid_members table
+-- ============================================
+CREATE TABLE masjid_members (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  masjid_id UUID NOT NULL REFERENCES masjid_profiles(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  role TEXT NOT NULL DEFAULT 'moderator' CHECK (role IN ('admin', 'moderator')),
+  last_active_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(masjid_id, user_id)
+);
+
+CREATE INDEX idx_masjid_members_user_id ON masjid_members(user_id);
+CREATE INDEX idx_masjid_members_masjid_id ON masjid_members(masjid_id);
+
+-- ============================================
+-- 2. Add masjid_id to content tables
+-- ============================================
+ALTER TABLE ayat_and_hadith ADD COLUMN masjid_id UUID REFERENCES masjid_profiles(id) ON DELETE CASCADE;
+ALTER TABLE announcements ADD COLUMN masjid_id UUID REFERENCES masjid_profiles(id) ON DELETE CASCADE;
+ALTER TABLE events ADD COLUMN masjid_id UUID REFERENCES masjid_profiles(id) ON DELETE CASCADE;
+ALTER TABLE posts ADD COLUMN masjid_id UUID REFERENCES masjid_profiles(id) ON DELETE CASCADE;
+ALTER TABLE youtube_videos ADD COLUMN masjid_id UUID REFERENCES masjid_profiles(id) ON DELETE CASCADE;
+
+-- ============================================
+-- 3. Add masjid_id to admin-only tables
+-- ============================================
+ALTER TABLE display_screens ADD COLUMN masjid_id UUID REFERENCES masjid_profiles(id) ON DELETE CASCADE;
+ALTER TABLE prayer_times ADD COLUMN masjid_id UUID REFERENCES masjid_profiles(id) ON DELETE CASCADE;
+ALTER TABLE settings ADD COLUMN masjid_id UUID REFERENCES masjid_profiles(id) ON DELETE CASCADE;
+
+-- ============================================
+-- 4. Backfill masjid_id from user_id
+-- ============================================
+UPDATE ayat_and_hadith SET masjid_id = mp.id FROM masjid_profiles mp WHERE ayat_and_hadith.user_id = mp.user_id;
+UPDATE announcements SET masjid_id = mp.id FROM masjid_profiles mp WHERE announcements.user_id = mp.user_id;
+UPDATE events SET masjid_id = mp.id FROM masjid_profiles mp WHERE events.user_id = mp.user_id;
+UPDATE posts SET masjid_id = mp.id FROM masjid_profiles mp WHERE posts.user_id = mp.user_id;
+UPDATE youtube_videos SET masjid_id = mp.id FROM masjid_profiles mp WHERE youtube_videos.user_id = mp.user_id;
+UPDATE display_screens SET masjid_id = mp.id FROM masjid_profiles mp WHERE display_screens.user_id = mp.user_id;
+UPDATE prayer_times SET masjid_id = mp.id FROM masjid_profiles mp WHERE prayer_times.user_id = mp.user_id;
+UPDATE settings SET masjid_id = mp.id FROM masjid_profiles mp WHERE settings.user_id = mp.user_id;
+
+-- Delete orphaned rows that have no matching masjid profile
+DELETE FROM ayat_and_hadith WHERE masjid_id IS NULL;
+DELETE FROM announcements WHERE masjid_id IS NULL;
+DELETE FROM events WHERE masjid_id IS NULL;
+DELETE FROM posts WHERE masjid_id IS NULL;
+DELETE FROM youtube_videos WHERE masjid_id IS NULL;
+DELETE FROM display_screens WHERE masjid_id IS NULL;
+DELETE FROM prayer_times WHERE masjid_id IS NULL;
+DELETE FROM settings WHERE masjid_id IS NULL;
+
+-- ============================================
+-- 5. Set masjid_id NOT NULL
+-- ============================================
+ALTER TABLE ayat_and_hadith ALTER COLUMN masjid_id SET NOT NULL;
+ALTER TABLE announcements ALTER COLUMN masjid_id SET NOT NULL;
+ALTER TABLE events ALTER COLUMN masjid_id SET NOT NULL;
+ALTER TABLE posts ALTER COLUMN masjid_id SET NOT NULL;
+ALTER TABLE youtube_videos ALTER COLUMN masjid_id SET NOT NULL;
+ALTER TABLE display_screens ALTER COLUMN masjid_id SET NOT NULL;
+ALTER TABLE prayer_times ALTER COLUMN masjid_id SET NOT NULL;
+ALTER TABLE settings ALTER COLUMN masjid_id SET NOT NULL;
+
+-- ============================================
+-- 6. Add indexes on masjid_id
+-- ============================================
+CREATE INDEX idx_ayat_and_hadith_masjid_id ON ayat_and_hadith(masjid_id);
+CREATE INDEX idx_announcements_masjid_id ON announcements(masjid_id);
+CREATE INDEX idx_events_masjid_id ON events(masjid_id);
+CREATE INDEX idx_posts_masjid_id ON posts(masjid_id);
+CREATE INDEX idx_youtube_videos_masjid_id ON youtube_videos(masjid_id);
+CREATE INDEX idx_display_screens_masjid_id ON display_screens(masjid_id);
+
+-- ============================================
+-- 7. Seed existing users as admins
+-- ============================================
+INSERT INTO masjid_members (masjid_id, user_id, role)
+SELECT id, user_id, 'admin'
+FROM masjid_profiles;
+
+-- ============================================
+-- 8. RLS helper functions
+-- ============================================
+CREATE OR REPLACE FUNCTION get_user_masjid_id()
+RETURNS UUID AS $$
+  SELECT masjid_id FROM masjid_members WHERE user_id = auth.uid() LIMIT 1;
+$$ LANGUAGE sql STABLE SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION get_user_role()
+RETURNS TEXT AS $$
+  SELECT role FROM masjid_members WHERE user_id = auth.uid() LIMIT 1;
+$$ LANGUAGE sql STABLE SECURITY DEFINER;
+
+-- ============================================
+-- 9. Activity tracking trigger
+-- ============================================
+CREATE OR REPLACE FUNCTION update_member_last_active()
+RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE masjid_members
+  SET last_active_at = now(), updated_at = now()
+  WHERE user_id = auth.uid();
+  RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER trg_update_last_active_ayat
+  AFTER INSERT OR UPDATE OR DELETE ON ayat_and_hadith
+  FOR EACH ROW EXECUTE FUNCTION update_member_last_active();
+
+CREATE TRIGGER trg_update_last_active_announcements
+  AFTER INSERT OR UPDATE OR DELETE ON announcements
+  FOR EACH ROW EXECUTE FUNCTION update_member_last_active();
+
+CREATE TRIGGER trg_update_last_active_events
+  AFTER INSERT OR UPDATE OR DELETE ON events
+  FOR EACH ROW EXECUTE FUNCTION update_member_last_active();
+
+CREATE TRIGGER trg_update_last_active_posts
+  AFTER INSERT OR UPDATE OR DELETE ON posts
+  FOR EACH ROW EXECUTE FUNCTION update_member_last_active();
+
+CREATE TRIGGER trg_update_last_active_youtube
+  AFTER INSERT OR UPDATE OR DELETE ON youtube_videos
+  FOR EACH ROW EXECUTE FUNCTION update_member_last_active();

--- a/supabase/migrations/20260408000002_rewrite_rls_for_moderators.sql
+++ b/supabase/migrations/20260408000002_rewrite_rls_for_moderators.sql
@@ -1,0 +1,283 @@
+-- ============================================
+-- Rewrite RLS policies for moderator support.
+-- Moves from user_id = auth.uid() to
+-- masjid_id = get_user_masjid_id() with role checks.
+-- ============================================
+
+-- ============================================
+-- 1. masjid_members RLS
+-- ============================================
+ALTER TABLE masjid_members ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Members can view own masjid members"
+  ON masjid_members FOR SELECT
+  TO authenticated
+  USING (masjid_id = get_user_masjid_id());
+
+CREATE POLICY "Admins can insert masjid members"
+  ON masjid_members FOR INSERT
+  TO authenticated
+  WITH CHECK (masjid_id = get_user_masjid_id() AND get_user_role() = 'admin');
+
+CREATE POLICY "Admins can delete masjid members"
+  ON masjid_members FOR DELETE
+  TO authenticated
+  USING (masjid_id = get_user_masjid_id() AND get_user_role() = 'admin');
+
+-- Members can update their own row (for last_active_at via trigger)
+CREATE POLICY "Members can update own membership"
+  ON masjid_members FOR UPDATE
+  TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+-- Admins can update any member in their masjid
+CREATE POLICY "Admins can update masjid members"
+  ON masjid_members FOR UPDATE
+  TO authenticated
+  USING (masjid_id = get_user_masjid_id() AND get_user_role() = 'admin')
+  WITH CHECK (masjid_id = get_user_masjid_id() AND get_user_role() = 'admin');
+
+-- ============================================
+-- 2. Content tables: any member can CRUD
+-- ============================================
+
+-- ayat_and_hadith
+DROP POLICY IF EXISTS "Users can view own ayat_and_hadith" ON ayat_and_hadith;
+DROP POLICY IF EXISTS "Users can insert own ayat_and_hadith" ON ayat_and_hadith;
+DROP POLICY IF EXISTS "Users can update own ayat_and_hadith" ON ayat_and_hadith;
+DROP POLICY IF EXISTS "Users can delete own ayat_and_hadith" ON ayat_and_hadith;
+
+CREATE POLICY "Members can view masjid ayat_and_hadith"
+  ON ayat_and_hadith FOR SELECT TO authenticated
+  USING (masjid_id = get_user_masjid_id());
+
+CREATE POLICY "Members can insert masjid ayat_and_hadith"
+  ON ayat_and_hadith FOR INSERT TO authenticated
+  WITH CHECK (masjid_id = get_user_masjid_id());
+
+CREATE POLICY "Members can update masjid ayat_and_hadith"
+  ON ayat_and_hadith FOR UPDATE TO authenticated
+  USING (masjid_id = get_user_masjid_id())
+  WITH CHECK (masjid_id = get_user_masjid_id());
+
+CREATE POLICY "Members can delete masjid ayat_and_hadith"
+  ON ayat_and_hadith FOR DELETE TO authenticated
+  USING (masjid_id = get_user_masjid_id());
+
+-- announcements
+DROP POLICY IF EXISTS "Users can view own announcements" ON announcements;
+DROP POLICY IF EXISTS "Users can insert own announcements" ON announcements;
+DROP POLICY IF EXISTS "Users can update own announcements" ON announcements;
+DROP POLICY IF EXISTS "Users can delete own announcements" ON announcements;
+
+CREATE POLICY "Members can view masjid announcements"
+  ON announcements FOR SELECT TO authenticated
+  USING (masjid_id = get_user_masjid_id());
+
+CREATE POLICY "Members can insert masjid announcements"
+  ON announcements FOR INSERT TO authenticated
+  WITH CHECK (masjid_id = get_user_masjid_id());
+
+CREATE POLICY "Members can update masjid announcements"
+  ON announcements FOR UPDATE TO authenticated
+  USING (masjid_id = get_user_masjid_id())
+  WITH CHECK (masjid_id = get_user_masjid_id());
+
+CREATE POLICY "Members can delete masjid announcements"
+  ON announcements FOR DELETE TO authenticated
+  USING (masjid_id = get_user_masjid_id());
+
+-- events
+DROP POLICY IF EXISTS "Users can view own events" ON events;
+DROP POLICY IF EXISTS "Users can insert own events" ON events;
+DROP POLICY IF EXISTS "Users can update own events" ON events;
+DROP POLICY IF EXISTS "Users can delete own events" ON events;
+
+CREATE POLICY "Members can view masjid events"
+  ON events FOR SELECT TO authenticated
+  USING (masjid_id = get_user_masjid_id());
+
+CREATE POLICY "Members can insert masjid events"
+  ON events FOR INSERT TO authenticated
+  WITH CHECK (masjid_id = get_user_masjid_id());
+
+CREATE POLICY "Members can update masjid events"
+  ON events FOR UPDATE TO authenticated
+  USING (masjid_id = get_user_masjid_id())
+  WITH CHECK (masjid_id = get_user_masjid_id());
+
+CREATE POLICY "Members can delete masjid events"
+  ON events FOR DELETE TO authenticated
+  USING (masjid_id = get_user_masjid_id());
+
+-- posts
+DROP POLICY IF EXISTS "Users can view own posts" ON posts;
+DROP POLICY IF EXISTS "Users can insert own posts" ON posts;
+DROP POLICY IF EXISTS "Users can update own posts" ON posts;
+DROP POLICY IF EXISTS "Users can delete own posts" ON posts;
+
+CREATE POLICY "Members can view masjid posts"
+  ON posts FOR SELECT TO authenticated
+  USING (masjid_id = get_user_masjid_id());
+
+CREATE POLICY "Members can insert masjid posts"
+  ON posts FOR INSERT TO authenticated
+  WITH CHECK (masjid_id = get_user_masjid_id());
+
+CREATE POLICY "Members can update masjid posts"
+  ON posts FOR UPDATE TO authenticated
+  USING (masjid_id = get_user_masjid_id())
+  WITH CHECK (masjid_id = get_user_masjid_id());
+
+CREATE POLICY "Members can delete masjid posts"
+  ON posts FOR DELETE TO authenticated
+  USING (masjid_id = get_user_masjid_id());
+
+-- youtube_videos
+DROP POLICY IF EXISTS "Users can view their own youtube videos" ON youtube_videos;
+DROP POLICY IF EXISTS "Users can insert their own youtube videos" ON youtube_videos;
+DROP POLICY IF EXISTS "Users can update their own youtube videos" ON youtube_videos;
+
+CREATE POLICY "Members can view masjid youtube_videos"
+  ON youtube_videos FOR SELECT TO authenticated
+  USING (masjid_id = get_user_masjid_id());
+
+CREATE POLICY "Members can insert masjid youtube_videos"
+  ON youtube_videos FOR INSERT TO authenticated
+  WITH CHECK (masjid_id = get_user_masjid_id());
+
+CREATE POLICY "Members can update masjid youtube_videos"
+  ON youtube_videos FOR UPDATE TO authenticated
+  USING (masjid_id = get_user_masjid_id())
+  WITH CHECK (masjid_id = get_user_masjid_id());
+
+CREATE POLICY "Members can delete masjid youtube_videos"
+  ON youtube_videos FOR DELETE TO authenticated
+  USING (masjid_id = get_user_masjid_id());
+
+-- ============================================
+-- 3. Admin-only tables: SELECT for all members,
+--    mutations for admins only
+-- ============================================
+
+-- masjid_profiles
+DROP POLICY IF EXISTS "Users can view own masjid profile" ON masjid_profiles;
+DROP POLICY IF EXISTS "Users can insert own masjid profile" ON masjid_profiles;
+DROP POLICY IF EXISTS "Users can update own masjid profile" ON masjid_profiles;
+DROP POLICY IF EXISTS "Users can delete own masjid profile" ON masjid_profiles;
+
+CREATE POLICY "Members can view masjid profile"
+  ON masjid_profiles FOR SELECT TO authenticated
+  USING (id = get_user_masjid_id());
+
+CREATE POLICY "Admins can insert masjid profile"
+  ON masjid_profiles FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "Admins can update masjid profile"
+  ON masjid_profiles FOR UPDATE TO authenticated
+  USING (id = get_user_masjid_id() AND get_user_role() = 'admin')
+  WITH CHECK (id = get_user_masjid_id() AND get_user_role() = 'admin');
+
+CREATE POLICY "Admins can delete masjid profile"
+  ON masjid_profiles FOR DELETE TO authenticated
+  USING (id = get_user_masjid_id() AND get_user_role() = 'admin');
+
+-- display_screens
+DROP POLICY IF EXISTS "Users can view own display screens" ON display_screens;
+DROP POLICY IF EXISTS "Users can insert own display screens" ON display_screens;
+DROP POLICY IF EXISTS "Users can update own display screens" ON display_screens;
+DROP POLICY IF EXISTS "Users can delete own display screens" ON display_screens;
+
+CREATE POLICY "Members can view masjid display screens"
+  ON display_screens FOR SELECT TO authenticated
+  USING (masjid_id = get_user_masjid_id());
+
+CREATE POLICY "Admins can insert masjid display screens"
+  ON display_screens FOR INSERT TO authenticated
+  WITH CHECK (masjid_id = get_user_masjid_id() AND get_user_role() = 'admin');
+
+CREATE POLICY "Admins can update masjid display screens"
+  ON display_screens FOR UPDATE TO authenticated
+  USING (masjid_id = get_user_masjid_id() AND get_user_role() = 'admin')
+  WITH CHECK (masjid_id = get_user_masjid_id() AND get_user_role() = 'admin');
+
+CREATE POLICY "Admins can delete masjid display screens"
+  ON display_screens FOR DELETE TO authenticated
+  USING (masjid_id = get_user_masjid_id() AND get_user_role() = 'admin');
+
+-- screen_content (admin-only mutations, member reads)
+DROP POLICY IF EXISTS "Users can view own screen content" ON screen_content;
+DROP POLICY IF EXISTS "Users can insert own screen content" ON screen_content;
+DROP POLICY IF EXISTS "Users can update own screen content" ON screen_content;
+DROP POLICY IF EXISTS "Users can delete own screen content" ON screen_content;
+
+CREATE POLICY "Members can view masjid screen content"
+  ON screen_content FOR SELECT TO authenticated
+  USING (screen_id IN (SELECT id FROM display_screens WHERE masjid_id = get_user_masjid_id()));
+
+CREATE POLICY "Admins can insert masjid screen content"
+  ON screen_content FOR INSERT TO authenticated
+  WITH CHECK (screen_id IN (SELECT id FROM display_screens WHERE masjid_id = get_user_masjid_id()) AND get_user_role() = 'admin');
+
+CREATE POLICY "Admins can update masjid screen content"
+  ON screen_content FOR UPDATE TO authenticated
+  USING (screen_id IN (SELECT id FROM display_screens WHERE masjid_id = get_user_masjid_id()) AND get_user_role() = 'admin')
+  WITH CHECK (screen_id IN (SELECT id FROM display_screens WHERE masjid_id = get_user_masjid_id()) AND get_user_role() = 'admin');
+
+CREATE POLICY "Admins can delete masjid screen content"
+  ON screen_content FOR DELETE TO authenticated
+  USING (screen_id IN (SELECT id FROM display_screens WHERE masjid_id = get_user_masjid_id()) AND get_user_role() = 'admin');
+
+-- prayer_times
+DROP POLICY IF EXISTS "Users can view own prayer_times" ON prayer_times;
+DROP POLICY IF EXISTS "Users can insert own prayer_times" ON prayer_times;
+DROP POLICY IF EXISTS "Users can update own prayer_times" ON prayer_times;
+DROP POLICY IF EXISTS "Users can delete own prayer_times" ON prayer_times;
+
+CREATE POLICY "Members can view masjid prayer_times"
+  ON prayer_times FOR SELECT TO authenticated
+  USING (masjid_id = get_user_masjid_id());
+
+CREATE POLICY "Admins can insert masjid prayer_times"
+  ON prayer_times FOR INSERT TO authenticated
+  WITH CHECK (masjid_id = get_user_masjid_id() AND get_user_role() = 'admin');
+
+CREATE POLICY "Admins can update masjid prayer_times"
+  ON prayer_times FOR UPDATE TO authenticated
+  USING (masjid_id = get_user_masjid_id() AND get_user_role() = 'admin')
+  WITH CHECK (masjid_id = get_user_masjid_id() AND get_user_role() = 'admin');
+
+CREATE POLICY "Admins can delete masjid prayer_times"
+  ON prayer_times FOR DELETE TO authenticated
+  USING (masjid_id = get_user_masjid_id() AND get_user_role() = 'admin');
+
+-- settings
+DROP POLICY IF EXISTS "Users can view own settings" ON settings;
+DROP POLICY IF EXISTS "Users can insert own settings" ON settings;
+DROP POLICY IF EXISTS "Users can update own settings" ON settings;
+DROP POLICY IF EXISTS "Users can delete own settings" ON settings;
+
+CREATE POLICY "Members can view masjid settings"
+  ON settings FOR SELECT TO authenticated
+  USING (masjid_id = get_user_masjid_id());
+
+CREATE POLICY "Admins can insert masjid settings"
+  ON settings FOR INSERT TO authenticated
+  WITH CHECK (masjid_id = get_user_masjid_id() AND get_user_role() = 'admin');
+
+CREATE POLICY "Admins can update masjid settings"
+  ON settings FOR UPDATE TO authenticated
+  USING (masjid_id = get_user_masjid_id() AND get_user_role() = 'admin')
+  WITH CHECK (masjid_id = get_user_masjid_id() AND get_user_role() = 'admin');
+
+CREATE POLICY "Admins can delete masjid settings"
+  ON settings FOR DELETE TO authenticated
+  USING (masjid_id = get_user_masjid_id() AND get_user_role() = 'admin');
+
+-- ============================================
+-- 4. Anon policies remain unchanged
+-- ============================================
+-- All existing anon SELECT policies are unaffected
+-- as they don't reference user_id or masjid_id.

--- a/supabase/migrations/20260408000003_unique_user_in_masjid_members.sql
+++ b/supabase/migrations/20260408000003_unique_user_in_masjid_members.sql
@@ -1,0 +1,2 @@
+-- Ensure a user can only belong to one masjid
+ALTER TABLE masjid_members ADD CONSTRAINT masjid_members_user_id_unique UNIQUE (user_id);

--- a/supabase/migrations/20260408000004_add_name_to_masjid_members.sql
+++ b/supabase/migrations/20260408000004_add_name_to_masjid_members.sql
@@ -1,0 +1,1 @@
+ALTER TABLE masjid_members ADD COLUMN name TEXT NOT NULL DEFAULT '';


### PR DESCRIPTION
## Summary

- Admins can invite and manage moderators who can manage content (ayat, announcements, events, posts, videos) without access to settings, screens, or prayer configuration
- Migrates data model from `user_id`-based ownership to `masjid_id`-based ownership via a `masjid_members` membership table
- Adds role-based access control (admin/moderator) enforced at both RLS and UI levels
- Moderator revocation deletes the auth user entirely, invalidating sessions immediately

## Changes

### Database
- New `masjid_members` table with role-based membership
- Added `masjid_id` column to all content and admin tables with backfill
- Rewrote all RLS policies from `user_id = auth.uid()` to `masjid_id = get_user_masjid_id()`
- DB triggers track `last_active_at` on content mutations

### Edge Functions
- `create-moderator` — creates auth user + membership (with rollback)
- `revoke-moderator` — deletes membership + auth user (hard terminate)
- `get-moderators` — lists moderators enriched with email

### Frontend
- New Moderators management page with add/revoke dialogs
- Auth store (Zustand) for role and masjid context
- Sidebar and home page filtered by role
- Admin-only route protection via `RequireAdmin` wrapper
- All services updated to use `masjid_id` for queries

## Test plan

- [ ] Login as admin — verify full sidebar, all features accessible
- [ ] Create a moderator from Moderators page
- [ ] Login as moderator — verify restricted sidebar (no Screens, Settings, Prayer Timings)
- [ ] Moderator can CRUD content (announcements, events, etc.)
- [ ] Moderator cannot access admin routes via URL
- [ ] Revoke moderator — verify immediate session invalidation
- [ ] Display screen flow still works (login with code)
- [ ] Verify `last_active_at` updates on content actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)