### PR TITLE
fix(display): keep screen awake via Wake Lock API

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -10,3 +10,4 @@ export * from './useAdjustedHijriDate';
 export * from './useSettings';
 export * from './useLocationSearch';
 export * from './useOrientationMismatch';
+export * from './useWakeLock';

--- a/src/hooks/useWakeLock.ts
+++ b/src/hooks/useWakeLock.ts
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+
+export function useWakeLock(enabled: boolean = true) {
+  useEffect(() => {
+    if (!enabled) return;
+    if (typeof navigator === 'undefined' || !('wakeLock' in navigator)) return;
+
+    let sentinel: WakeLockSentinel | null = null;
+    let cancelled = false;
+
+    const request = async () => {
+      if (document.visibilityState !== 'visible') return;
+      try {
+        const lock = await navigator.wakeLock.request('screen');
+        if (cancelled) {
+          lock.release().catch(error => {
+            console.warn('Failed to release wake lock', error);
+          });
+          return;
+        }
+        sentinel = lock;
+        sentinel.addEventListener('release', () => {
+          sentinel = null;
+        });
+      } catch (error) {
+        if ((error as Error)?.name === 'NotAllowedError') return;
+        console.warn('Failed to acquire wake lock', error);
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible' && !sentinel) request();
+    };
+
+    request();
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      sentinel?.release().catch(error => {
+        console.warn('Failed to release wake lock', error);
+      });
+      sentinel = null;
+    };
+  }, [enabled]);
+}

--- a/src/pages/app/display.tsx
+++ b/src/pages/app/display.tsx
@@ -3,6 +3,7 @@ import {
   useFetchDisplayData,
   useOrientationMismatch,
   usePrayerTimings,
+  useWakeLock,
   useWeatherData,
 } from '@/hooks';
 import { useDisplayStore } from '@/store';
@@ -26,6 +27,8 @@ import './display.css';
 const SLIDE_DELAY = 9000;
 
 export default function Display() {
+  useWakeLock();
+
   const swiperRef = useRef<SwiperType | null>(null);
   const [activeSlideIndex, setActiveSlideIndex] = useState(0);
 


### PR DESCRIPTION
## Summary
- Adds a `useWakeLock` hook that requests a screen wake lock to prevent masjid TV screens from going to sleep due to inactivity.
- Re-acquires the lock on `visibilitychange` since browsers automatically release it when the tab becomes hidden.
- Silently no-ops on browsers without Wake Lock API support (pre-Chrome 84, older Android WebViews).

## Why
Customers running the display on masjid screens reported that the screen would turn off after some time due to OS/browser inactivity timers.

## Caveats
- Wake Lock API requires HTTPS and Chrome 84+ / Safari 16.4+ / Firefox 126+. On older devices (e.g., some X96Q / X99-class Android TV boxes with outdated WebView), the hook has no effect — admins should also disable the OS-level sleep timer for those devices.
- `NotAllowedError` (spec-level rejection when the page is not visible) is swallowed silently; other failures are logged to the console.

## Test plan
- [ ] Open the display in Chrome, verify the screen does not sleep after 5+ minutes of idle.
- [ ] Switch tabs and back; confirm the lock is re-acquired (no console errors).
- [ ] Load in an older browser without Wake Lock support; confirm no errors thrown and display still works.