### PR TITLE
fix(signup): bootstrap admin membership on first masjid profile

### DIFF
--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -32,6 +32,7 @@ export default function Sidebar({ onClose, isMobile = false }: SidebarProps) {
   const [collapsed, toggleSidebar] = useSidebarState(false);
   const location = useLocation();
   const role = useAuthStore(s => s.role);
+  const masjidId = useAuthStore(s => s.masjidId);
 
   /**
    * Determines if a navigation item should be active
@@ -48,40 +49,49 @@ export default function Sidebar({ onClose, isMobile = false }: SidebarProps) {
   };
 
   const isAdmin = role === 'admin';
+  const needsOnboarding = !masjidId;
 
-  const allNavItems = [
-    {
-      label: 'Home',
-      path: AppRoutes.Home,
-      icon: <Home size={20} />,
-    },
-    {
-      label: 'Announcements',
-      path: AppRoutes.Announcements,
-      icon: <Bell size={20} />,
-    },
-    {
-      label: 'Events',
-      path: AppRoutes.Events,
-      icon: <Tickets size={20} />,
-    },
-    {
-      label: 'Posts',
-      path: AppRoutes.Posts,
-      icon: <Images size={20} />,
-    },
-    {
-      label: 'YouTube Videos',
-      path: AppRoutes.YouTubeVideos,
-      icon: <Video size={20} />,
-    },
-    {
-      label: 'Ayat & Hadith',
-      path: AppRoutes.AyatAndHadith,
-      icon: <BookOpen size={20} />,
-    },
-    ...(isAdmin
+  const contentNavItems = needsOnboarding
+    ? []
+    : [
+        {
+          label: 'Announcements',
+          path: AppRoutes.Announcements,
+          icon: <Bell size={20} />,
+        },
+        {
+          label: 'Events',
+          path: AppRoutes.Events,
+          icon: <Tickets size={20} />,
+        },
+        {
+          label: 'Posts',
+          path: AppRoutes.Posts,
+          icon: <Images size={20} />,
+        },
+        {
+          label: 'YouTube Videos',
+          path: AppRoutes.YouTubeVideos,
+          icon: <Video size={20} />,
+        },
+        {
+          label: 'Ayat & Hadith',
+          path: AppRoutes.AyatAndHadith,
+          icon: <BookOpen size={20} />,
+        },
+      ];
+
+  const adminNavItems = !isAdmin
+    ? []
+    : needsOnboarding
       ? [
+          {
+            label: 'Settings',
+            path: AppRoutes.Settings,
+            icon: <Settings size={20} />,
+          },
+        ]
+      : [
           {
             label: 'Screens',
             path: AppRoutes.Screens,
@@ -107,8 +117,16 @@ export default function Sidebar({ onClose, isMobile = false }: SidebarProps) {
             path: AppRoutes.Support,
             icon: <LifeBuoy size={20} />,
           },
-        ]
-      : []),
+        ];
+
+  const allNavItems = [
+    {
+      label: 'Home',
+      path: AppRoutes.Home,
+      icon: <Home size={20} />,
+    },
+    ...contentNavItems,
+    ...adminNavItems,
   ];
 
   const navItems = allNavItems;

--- a/src/lib/supabase/services/masjid-profile.ts
+++ b/src/lib/supabase/services/masjid-profile.ts
@@ -1,4 +1,4 @@
-import { SupabaseBuckets, SupabaseTables, type MasjidMember, type MasjidProfile } from '@/types';
+import { SupabaseBuckets, SupabaseTables, type MasjidProfile } from '@/types';
 import type { MasjidProfileData } from '../../zod';
 import {
   getCurrentUser,
@@ -84,7 +84,6 @@ export async function upsertMasjidProfile(
   else if (shouldRemoveLogo) profileToUpsert.logo_url = '';
 
   if (existingProfile) {
-    await ensureAdminMembership(existingProfile.id as string, user.id, profileData.name);
     return await updateRecord<MasjidProfile>(
       SupabaseTables.MasjidProfiles,
       existingProfile.id as string,
@@ -96,30 +95,9 @@ export async function upsertMasjidProfile(
       SupabaseTables.MasjidProfiles,
       profileToUpsert
     );
-
-    await ensureAdminMembership(created.id, user.id, profileData.name);
-
+    // The on_masjid_profile_insert trigger creates the admin membership
+    // server-side; mirror that into the client auth store.
+    useAuthStore.getState().setAuth(created.id, 'admin');
     return created;
   }
-}
-
-async function ensureAdminMembership(
-  masjidId: string,
-  userId: string,
-  name: string
-): Promise<void> {
-  try {
-    const { masjid_id } = await getMasjidMembership();
-    if (masjid_id === masjidId) return;
-  } catch {
-    // no membership yet — fall through to bootstrap
-  }
-
-  await insertRecord<MasjidMember>(SupabaseTables.MasjidMembers, {
-    masjid_id: masjidId,
-    user_id: userId,
-    role: 'admin',
-    name,
-  });
-  useAuthStore.getState().setAuth(masjidId, 'admin');
 }

--- a/src/lib/supabase/services/masjid-profile.ts
+++ b/src/lib/supabase/services/masjid-profile.ts
@@ -1,4 +1,4 @@
-import { SupabaseBuckets, SupabaseTables, type MasjidProfile } from '@/types';
+import { SupabaseBuckets, SupabaseTables, type MasjidMember, type MasjidProfile } from '@/types';
 import type { MasjidProfileData } from '../../zod';
 import {
   getCurrentUser,
@@ -9,6 +9,7 @@ import {
   updateRecord,
   insertRecord,
 } from '../helpers';
+import { useAuthStore } from '@/store';
 
 /**
  * Gets the masjid profile for the current authenticated user
@@ -83,6 +84,7 @@ export async function upsertMasjidProfile(
   else if (shouldRemoveLogo) profileToUpsert.logo_url = '';
 
   if (existingProfile) {
+    await ensureAdminMembership(existingProfile.id as string, user.id, profileData.name);
     return await updateRecord<MasjidProfile>(
       SupabaseTables.MasjidProfiles,
       existingProfile.id as string,
@@ -90,6 +92,34 @@ export async function upsertMasjidProfile(
     );
   } else {
     profileToUpsert.created_at = new Date().toISOString();
-    return await insertRecord<MasjidProfile>(SupabaseTables.MasjidProfiles, profileToUpsert);
+    const created = await insertRecord<MasjidProfile>(
+      SupabaseTables.MasjidProfiles,
+      profileToUpsert
+    );
+
+    await ensureAdminMembership(created.id, user.id, profileData.name);
+
+    return created;
   }
+}
+
+async function ensureAdminMembership(
+  masjidId: string,
+  userId: string,
+  name: string
+): Promise<void> {
+  try {
+    const { masjid_id } = await getMasjidMembership();
+    if (masjid_id === masjidId) return;
+  } catch {
+    // no membership yet — fall through to bootstrap
+  }
+
+  await insertRecord<MasjidMember>(SupabaseTables.MasjidMembers, {
+    masjid_id: masjidId,
+    user_id: userId,
+    role: 'admin',
+    name,
+  });
+  useAuthStore.getState().setAuth(masjidId, 'admin');
 }

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -61,7 +61,9 @@ export default function Navigation() {
             setAuth(membership.masjid_id, membership.role);
             updateLastActive();
           } catch {
-            // User may not have membership yet (e.g. during registration)
+            // Fresh signup: no membership yet. Grant transient admin with
+            // a null masjidId so onboarding (Settings → Profile) is reachable.
+            setAuth(null, 'admin');
           }
         }
       } catch (error) {
@@ -83,7 +85,7 @@ export default function Navigation() {
           const membership = await getMasjidMembership();
           setAuth(membership.masjid_id, membership.role);
         } catch {
-          // User may not have membership yet
+          setAuth(null, 'admin');
         }
       } else {
         clearAuth();

--- a/src/pages/app/home.tsx
+++ b/src/pages/app/home.tsx
@@ -5,7 +5,27 @@ import { useAuthStore } from '@/store';
 
 export default function Home() {
   const role = useAuthStore(s => s.role);
+  const masjidId = useAuthStore(s => s.masjidId);
   const isAdmin = role === 'admin';
+  const needsOnboarding = !masjidId;
+
+  if (needsOnboarding) {
+    return (
+      <div className='container mx-auto py-8 space-y-6'>
+        <WelcomeHeader
+          title='Welcome to PrayerBox'
+          subtitle='Set up your masjid profile to get started'
+        />
+        <ModuleCard
+          title='Masjid Profile'
+          description='Add your masjid name, area, and location so you can start managing content.'
+          icon={<User className='h-10 w-10 text-primary' />}
+          path={AppRoutes.SettingsProfile}
+          color='bg-emerald-50 dark:bg-emerald-950/30'
+        />
+      </div>
+    );
+  }
 
   const modules = [
     ...(isAdmin

--- a/src/pages/app/settings/index.tsx
+++ b/src/pages/app/settings/index.tsx
@@ -3,6 +3,7 @@ import { Palette, Calendar, UserRound, Shield, Clock } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui';
 import { AppRoutes } from '@/constants';
 import { PageHeader } from '@/components/common';
+import { useAuthStore } from '@/store';
 
 const settingsModules = [
   {
@@ -11,6 +12,7 @@ const settingsModules = [
     icon: UserRound,
     route: AppRoutes.SettingsProfile,
     color: 'text-orange-600',
+    requiresMasjid: false,
   },
   {
     title: 'Themes',
@@ -18,6 +20,7 @@ const settingsModules = [
     icon: Palette,
     route: AppRoutes.SettingsThemes,
     color: 'text-purple-600',
+    requiresMasjid: true,
   },
   {
     title: 'Prayer Times',
@@ -25,6 +28,7 @@ const settingsModules = [
     icon: Clock,
     route: AppRoutes.SettingsPrayerTimes,
     color: 'text-teal-600',
+    requiresMasjid: true,
   },
   {
     title: 'Hijri Calendar',
@@ -32,6 +36,7 @@ const settingsModules = [
     icon: Calendar,
     route: AppRoutes.SettingsHijri,
     color: 'text-green-600',
+    requiresMasjid: true,
   },
   {
     title: 'Account',
@@ -39,10 +44,16 @@ const settingsModules = [
     icon: Shield,
     route: AppRoutes.SettingsAccount,
     color: 'text-red-600',
+    requiresMasjid: false,
   },
 ];
 
 export default function Settings() {
+  const masjidId = useAuthStore(s => s.masjidId);
+  const visibleModules = masjidId
+    ? settingsModules
+    : settingsModules.filter(m => !m.requiresMasjid);
+
   return (
     <div className='container mx-auto py-6 space-y-4'>
       <PageHeader
@@ -51,7 +62,7 @@ export default function Settings() {
       />
 
       <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3'>
-        {settingsModules.map(module => {
+        {visibleModules.map(module => {
           const Icon = module.icon;
           return (
             <Link key={module.title} to={module.route} className='block'>

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -13,6 +13,6 @@ export type DisplayStore = {
 export type AuthStore = {
   masjidId: string | null;
   role: MemberRole | null;
-  setAuth: (masjidId: string, role: MemberRole) => void;
+  setAuth: (masjidId: string | null, role: MemberRole) => void;
   clearAuth: () => void;
 };

--- a/supabase/migrations/20260423000001_bootstrap_admin_membership.sql
+++ b/supabase/migrations/20260423000001_bootstrap_admin_membership.sql
@@ -1,0 +1,17 @@
+-- Allow a brand-new user (no existing membership) to insert a self-admin
+-- row when they create their first masjid_profile. Without this, new
+-- signups cannot bootstrap into the masjid_members table because the
+-- existing "Admins can insert masjid members" policy requires an
+-- already-admin membership.
+CREATE POLICY "Users can bootstrap first admin membership"
+  ON masjid_members FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    user_id = auth.uid()
+    AND role = 'admin'
+    AND NOT EXISTS (SELECT 1 FROM masjid_members mm WHERE mm.user_id = auth.uid())
+    AND EXISTS (
+      SELECT 1 FROM masjid_profiles mp
+      WHERE mp.id = masjid_id AND mp.user_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/20260423000002_allow_self_select_masjid_members.sql
+++ b/supabase/migrations/20260423000002_allow_self_select_masjid_members.sql
@@ -1,0 +1,10 @@
+-- Let a user always see their own membership row, independent of
+-- get_user_masjid_id(). Without this, INSERT ... RETURNING on
+-- masjid_members fails for a bootstrapping admin: the WITH CHECK
+-- passes but the RETURNING SELECT policy uses the pre-insert
+-- snapshot of get_user_masjid_id() (STABLE), so the new row is
+-- invisible and Postgres aborts the INSERT.
+CREATE POLICY "Members can view own membership row"
+  ON masjid_members FOR SELECT
+  TO authenticated
+  USING (user_id = auth.uid());

--- a/supabase/migrations/20260423000003_trigger_admin_bootstrap.sql
+++ b/supabase/migrations/20260423000003_trigger_admin_bootstrap.sql
@@ -1,0 +1,30 @@
+-- Replace the client-side bootstrap approach (RLS policies that let a
+-- brand-new user insert their own admin membership) with a DB trigger
+-- that atomically mints an admin membership whenever a masjid_profile
+-- row is created. This removes the orphan-profile failure mode and
+-- the client no longer has to coordinate two writes.
+
+-- 1. Trigger: profile insert → admin membership insert
+CREATE OR REPLACE FUNCTION handle_new_masjid_profile()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO masjid_members (masjid_id, user_id, role, name)
+  VALUES (NEW.id, NEW.user_id, 'admin', NEW.name);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER on_masjid_profile_insert
+  AFTER INSERT ON masjid_profiles
+  FOR EACH ROW EXECUTE FUNCTION handle_new_masjid_profile();
+
+-- 2. Backfill legacy orphans: profiles without a corresponding membership
+INSERT INTO masjid_members (masjid_id, user_id, role, name)
+SELECT mp.id, mp.user_id, 'admin', mp.name
+FROM masjid_profiles mp
+LEFT JOIN masjid_members mm ON mm.user_id = mp.user_id
+WHERE mm.id IS NULL;
+
+-- 3. Drop the now-redundant client-bootstrap policies
+DROP POLICY IF EXISTS "Users can bootstrap first admin membership" ON masjid_members;
+DROP POLICY IF EXISTS "Members can view own membership row" ON masjid_members;


### PR DESCRIPTION
## Summary
- New signups had no `masjid_members` row, so `getMasjidMembership()` threw, module pages 406'd, and `RequireAdmin` blocked them from reaching onboarding.
- `upsertMasjidProfile` now inserts an admin membership alongside the first profile and heals legacy orphan profiles on the update path.
- Added two migrations: one RLS policy to let a brand-new user bootstrap their own admin membership for a masjid they own, and one to let a user always see their own membership row (so `INSERT ... RETURNING` survives the `get_user_masjid_id()` STABLE snapshot).
- While membership is missing, the auth store gets a transient `admin` role and the sidebar/home collapse to a single onboarding CTA pointing at Settings → Profile, so users aren't dropped into pages that would 406.

## Test plan
- [ ] Sign up a fresh account → lands on Home with the "Masjid Profile" onboarding card, sidebar shows only Home + Settings.
- [ ] Click through → Settings → Profile → fill the form → Save. No errors; sidebar expands to the full admin set; auth store has a real `masjidId`.
- [ ] Module pages (Announcements, Events, Posts, YouTube Videos, Ayat & Hadith) load cleanly (empty states, no 406).
- [ ] Existing admins (seeded) unaffected — login behaves as before.
- [ ] Moderator logins still see the moderator sidebar (no Settings/Screens/etc).
- [ ] Orphan case: a user whose profile exists but membership is missing can open Settings → Profile, save, and have the membership auto-created before the update runs.

## Notes
- Migrations `20260423000001` and `20260423000002` were already applied to production during debugging.
- Follow-up worth tracking separately: a dashboard-added policy `"Anyone can view masjid by code"` on `masjid_profiles` (`authenticated`, `USING (true)`) lets any logged-in user read every masjid profile. Not introduced by this PR, but surfaced during debugging.