### PR TITLE
feat(ayat-hadith): scope overlay to text box and add citation header

### DIFF
--- a/src/components/ayat-hadith-designer/canvas.tsx
+++ b/src/components/ayat-hadith-designer/canvas.tsx
@@ -1,18 +1,40 @@
 import { forwardRef, useEffect, useRef, useState } from 'react';
-import { CANVAS_DIMENSIONS } from '@/constants';
-import type { AyatHadithCachedText, AyatHadithStyle, ScreenOrientation } from '@/types';
+import { CANVAS_DIMENSIONS, HADITH_BOOKS, SURAHS } from '@/constants';
+import type {
+  AyatHadithCachedText,
+  AyatHadithStyle,
+  AyatHadithType,
+  AyatSource,
+  HadithSource,
+  ScreenOrientation,
+} from '@/types';
 import { hexWithOpacity, resolveBackground, resolveFont } from './helpers';
 
 interface CanvasProps {
   orientation: ScreenOrientation;
+  type: AyatHadithType;
+  source: AyatSource | HadithSource;
   style: AyatHadithStyle;
   cachedText: AyatHadithCachedText;
   showUrdu: boolean;
   showEnglish: boolean;
 }
 
+function resolveSourceLine(type: AyatHadithType, source: AyatSource | HadithSource): string | null {
+  if (type === 'ayat') {
+    const s = source as AyatSource;
+    const surah = SURAHS.find(x => x.number === s.surah);
+    if (!surah) return null;
+    return `سُورَة ${surah.name_arabic} - ${surah.name_english} (Ch. ${surah.number})`;
+  }
+  const h = source as HadithSource;
+  const book = HADITH_BOOKS.find(b => b.slug === h.book);
+  if (!book || !h.hadith_number) return null;
+  return `${book.name_arabic} - ${book.name} (#${h.hadith_number})`;
+}
+
 export const Canvas = forwardRef<HTMLDivElement, CanvasProps>(function Canvas(
-  { orientation, style, cachedText, showUrdu, showEnglish },
+  { orientation, type, source, style, cachedText, showUrdu, showEnglish },
   ref
 ) {
   const [width, height] = CANVAS_DIMENSIONS[orientation];
@@ -40,6 +62,7 @@ export const Canvas = forwardRef<HTMLDivElement, CanvasProps>(function Canvas(
   const arabicFont = resolveFont('arabic', style.arabic.font_id);
   const urduFont = resolveFont('urdu', style.urdu.font_id);
   const englishFont = resolveFont('english', style.english.font_id);
+  const sourceLine = resolveSourceLine(type, source);
 
   const backgroundStyle: React.CSSProperties = (() => {
     if (bg.type === 'image') {
@@ -67,27 +90,64 @@ export const Canvas = forwardRef<HTMLDivElement, CanvasProps>(function Canvas(
           transformOrigin: 'center center',
           position: 'relative',
           flexShrink: 0,
+          padding: '6%',
           ...backgroundStyle,
         }}
       >
         <div
           style={{
             position: 'absolute',
-            inset: 0,
-            backgroundColor: hexWithOpacity(style.overlay_color, style.overlay_opacity),
+            top: '6%',
+            left: '6%',
+            right: '6%',
+            color: style.arabic.color,
+            textAlign: 'center',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: '0.4em',
           }}
-        />
+        >
+          <div
+            style={{
+              fontFamily: englishFont.family,
+              fontSize: Math.round(style.english.size * 0.85),
+              fontWeight: 600,
+              lineHeight: 1.2,
+            }}
+          >
+            I made this on <span style={{ fontWeight: 800 }}>PrayerBox</span>
+          </div>
+          {sourceLine && (
+            <div
+              style={{
+                fontFamily: englishFont.family,
+                fontSize: Math.round(style.english.size * 0.7),
+                opacity: 0.9,
+                lineHeight: 1.2,
+              }}
+            >
+              {sourceLine}
+            </div>
+          )}
+        </div>
         <div
           style={{
             position: 'absolute',
-            inset: 0,
-            padding: '6%',
+            top: '50%',
+            left: '10%',
+            right: '10%',
+            transform: 'translateY(-50%)',
+            padding: '4% 5%',
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',
             justifyContent: 'center',
             gap: '3%',
             textAlign: 'center',
+            overflow: 'hidden',
+            borderRadius: 16,
+            backgroundColor: hexWithOpacity(style.overlay_color, style.overlay_opacity),
           }}
         >
           {cachedText.arabic && (

--- a/src/pages/app/ayat-hadith-designer.tsx
+++ b/src/pages/app/ayat-hadith-designer.tsx
@@ -226,6 +226,8 @@ export default function AyatHadithDesigner() {
           <Canvas
             ref={canvasRef}
             orientation={orientation}
+            type={content.type}
+            source={buildSource()}
             style={style}
             cachedText={cachedText}
             showUrdu={content.showUrdu}


### PR DESCRIPTION
## Summary
- Restructure the slide so the tint/overlay wraps only the Ayat/translation text container (rounded box) instead of covering the full slide — the chosen background image shows through around the box, matching the Quran.com reference layout.
- Add a top-anchored header reading **"I made this on PrayerBox"** with a source citation line below it: Surah name (Arabic + English) and chapter number for Ayat slides, or book name (Arabic + English) and hadith number for Hadith slides.
- Text box uses fixed horizontal insets (10% on each side) so the Arabic line does not wrap when content is short.

## Test plan
- [ ] Create an Ayat slide: confirm header shows "I made this on PrayerBox" and "سُورَة {arabic} - {english} (Ch. {n})" pinned to the top.
- [ ] Create a Hadith slide: confirm header shows the book name and hadith number.
- [ ] Verify the overlay color/opacity only tints the text box (not the background image).
- [ ] Verify the Arabic line fits on a single line across landscape, portrait, and mobile orientations.
- [ ] Save an Ayat slide and view it on a display screen — the rendered PNG should match the preview.