### PR TITLE
fix: prayer settings defaults, warnings gating, and display slide null-safety

### DIFF
--- a/src/components/display/prayer-timings/index.tsx
+++ b/src/components/display/prayer-timings/index.tsx
@@ -39,7 +39,7 @@ export function PrayerTimingDisplay({
     offset: userSettings?.hijri_offset || 0,
   });
 
-  if (!prayerTimes || !userSettings || !prayerTimeSettings) return null;
+  if (!prayerTimes || !userSettings) return null;
 
   const timings = prayerTimes?.timings;
   const date = prayerTimes?.date;

--- a/src/components/settings/prayer-times-section.tsx
+++ b/src/components/settings/prayer-times-section.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/lib/supabase';
 import { MapPin } from 'lucide-react';
 import { Link } from 'react-router';
+import { isNullOrUndefined } from '@/utils';
 
 export function PrayerTimesSection() {
   const [isLoading, setIsLoading] = useState(true);
@@ -41,13 +42,11 @@ export function PrayerTimesSection() {
         setIsLoading(true);
         const [settings, profile] = await Promise.all([getOrCreateSettings(), getMasjidProfile()]);
 
-        if (settings) {
-          if (settings.calculation_method !== undefined) {
-            setCalculationMethod(settings.calculation_method);
-          }
-          if (settings.juristic_school !== undefined) {
-            setJuristicSchool(settings.juristic_school);
-          }
+        if (settings && !isNullOrUndefined(settings.calculation_method)) {
+          setCalculationMethod(settings.calculation_method);
+        }
+        if (settings && !isNullOrUndefined(settings.juristic_school)) {
+          setJuristicSchool(settings.juristic_school);
         }
 
         if (profile && profile.latitude && profile.longitude) {

--- a/src/hooks/useFetchDisplayData.ts
+++ b/src/hooks/useFetchDisplayData.ts
@@ -78,10 +78,11 @@ export function useFetchDisplayData(): ReturnType {
         // Update screen settings in store if changed
         setDisplayScreen(latestScreen);
 
-        if (!settings) {
+        if (!settings && latestScreen.show_prayer_times) {
           setErrorMessage({
-            title: 'User settings are not set',
-            description: 'Please set your user settings to continue',
+            title: 'Prayer time settings are missing',
+            description:
+              'Prayer times are enabled for this screen but calculation method and juristic school have not been configured. Please set them in the admin panel, or disable prayer times on this screen.',
           });
           return;
         }

--- a/src/hooks/usePrayerTimings.ts
+++ b/src/hooks/usePrayerTimings.ts
@@ -39,8 +39,9 @@ export function usePrayerTimings(enabled: boolean = true): ReturnType {
 
         if (isNullOrUndefined(latitude) || isNullOrUndefined(longitude)) {
           setErrorMessage({
-            title: 'Masjid profile is not set',
-            description: 'Please set your masjid profile to continue',
+            title: 'Masjid location is missing',
+            description:
+              'Prayer times need latitude and longitude from the masjid profile. Please set the location in the admin panel, or disable prayer times on this screen.',
           });
           return;
         }
@@ -50,8 +51,9 @@ export function usePrayerTimings(enabled: boolean = true): ReturnType {
 
         if (isNullOrUndefined(method) || isNullOrUndefined(school)) {
           setErrorMessage({
-            title: 'Prayer time settings are not set',
-            description: 'Please set your prayer time settings to continue',
+            title: 'Prayer calculation settings are missing',
+            description:
+              'Prayer times require a calculation method and juristic school. Please configure them in the admin panel, or disable prayer times on this screen.',
           });
           return;
         }

--- a/src/hooks/useWeatherData.ts
+++ b/src/hooks/useWeatherData.ts
@@ -26,9 +26,9 @@ export function useWeatherData(enabled: boolean = true) {
 
       if (isNullOrUndefined(latitude) || isNullOrUndefined(longitude)) {
         setErrorMessage({
-          title: 'Location not available',
+          title: 'Masjid location is missing',
           description:
-            'Weather data requires location coordinates to be set in your masjid profile',
+            'Weather requires latitude and longitude from the masjid profile. Please set the location in the admin panel, or disable weather on this screen.',
         });
         return;
       }

--- a/src/lib/supabase/services/prayer-times.ts
+++ b/src/lib/supabase/services/prayer-times.ts
@@ -25,6 +25,32 @@ export async function getPrayerAdjustments(masjidId?: string): Promise<PrayerTim
 }
 
 /**
+ * Gets the prayer_times row for the current user's masjid, creating a default
+ * (empty-adjustments) row if one does not exist yet.
+ */
+export async function getOrCreatePrayerAdjustments(): Promise<PrayerTimes | null> {
+  const existing = await getPrayerAdjustments();
+  if (existing) return existing;
+
+  const user = await getCurrentUser();
+  if (!user) return null;
+  const { masjid_id } = await getMasjidMembership();
+
+  try {
+    const now = new Date().toISOString();
+    return await insertRecord<PrayerTimes>(SupabaseTables.PrayerTimes, {
+      user_id: user.id,
+      masjid_id,
+      created_at: now,
+      updated_at: now,
+    });
+  } catch {
+    // Race or unique-constraint violation — another caller created it; just fetch.
+    return await getPrayerAdjustments();
+  }
+}
+
+/**
  * Saves or updates prayer adjustments for the current user's masjid
  * @param settings The prayer adjustments data to save
  * @returns Promise resolving to the saved prayer adjustments

--- a/src/lib/supabase/services/settings.ts
+++ b/src/lib/supabase/services/settings.ts
@@ -7,6 +7,7 @@ import {
   fetchByColumn,
   updateRecord,
 } from '../helpers';
+import { getOrCreatePrayerAdjustments } from './prayer-times';
 
 export async function getSettings(masjidId?: string): Promise<Settings | null> {
   try {
@@ -109,11 +110,15 @@ export async function updatePrayerCalculationSettings(
 }
 
 export async function getOrCreateSettings(): Promise<Settings | null> {
-  const settings = await getSettings();
-  if (settings) return settings;
+  const existing = await getSettings();
+  if (existing) return existing;
 
   try {
-    return await createDefaultSettings();
+    const created = await createDefaultSettings();
+    // Pair the settings defaults with a matching prayer_times row so the
+    // display has adjustments (even if empty) to render against.
+    await getOrCreatePrayerAdjustments();
+    return created;
   } catch {
     // If insert fails due to unique constraint (race condition from concurrent calls),
     // the record was already created — just fetch it.

--- a/src/pages/app/prayer-timings.tsx
+++ b/src/pages/app/prayer-timings.tsx
@@ -1,6 +1,10 @@
 import { useState, useEffect } from 'react';
 import { PrayerTimingsModal } from '@/components/modals';
-import { getMasjidProfile, getPrayerAdjustments, getOrCreateSettings } from '@/lib/supabase';
+import {
+  getMasjidProfile,
+  getOrCreatePrayerAdjustments,
+  getOrCreateSettings,
+} from '@/lib/supabase';
 import { toast } from 'sonner';
 import type { AlAdhanPrayerTimes, PrayerTimes, Settings } from '@/types';
 import { useTrigger } from '@/hooks';
@@ -66,7 +70,7 @@ export default function PrayerTimings() {
 
         const [settings, prayerSettings] = await Promise.all([
           getOrCreateSettings(),
-          getPrayerAdjustments(),
+          getOrCreatePrayerAdjustments(),
         ]);
         setUserSettings(settings);
         setSavedSettings(prayerSettings);

--- a/src/pages/app/prayer-timings.tsx
+++ b/src/pages/app/prayer-timings.tsx
@@ -17,7 +17,7 @@ import {
   LocationNotSet,
   PrayerTimingsSettingsNotSet,
 } from '@/components/prayer-times';
-import { getCurrentDate } from '@/utils';
+import { getCurrentDate, isNullOrUndefined } from '@/utils';
 
 const currentDate = getCurrentDate();
 
@@ -75,7 +75,11 @@ export default function PrayerTimings() {
         setUserSettings(settings);
         setSavedSettings(prayerSettings);
 
-        if (!settings?.calculation_method || !settings?.juristic_school) return;
+        if (
+          isNullOrUndefined(settings?.calculation_method) ||
+          isNullOrUndefined(settings?.juristic_school)
+        )
+          return;
 
         const response = await fetchPrayerTimesForThisMonth({
           date: currentDate,
@@ -119,7 +123,10 @@ export default function PrayerTimings() {
       return <LocationNotSet />;
     }
 
-    if (!userSettings?.calculation_method || !userSettings?.juristic_school) {
+    if (
+      isNullOrUndefined(userSettings?.calculation_method) ||
+      isNullOrUndefined(userSettings?.juristic_school)
+    ) {
       return <PrayerTimingsSettingsNotSet />;
     }
 

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -9,7 +9,7 @@ import { getAdjustedPrayerTime, PRAYER_NAMES } from './prayer-time-adjustments';
  */
 export function getProcessedPrayerTimings(
   prayerTimes: AlAdhanPrayerTimes,
-  prayerTimeSettings: PrayerTimes
+  prayerTimeSettings: PrayerTimes | null
 ): ProcessedPrayerTiming[] {
   const timings = prayerTimes.timings;
 


### PR DESCRIPTION
## Summary
Four focused fixes around prayer times configuration and display. Each fix lives in its own commit so it can be reviewed (or reverted) independently.

1. **`fix(display)` — hide prayer/weather warnings when feature is disabled for the screen.** The "User settings are not set" error from `useFetchDisplayData` previously blocked the display even on screens with `show_prayer_times=false`. It's now gated on the freshly-fetched `latestScreen.show_prayer_times` (no stale-closure window), and the error copy in `usePrayerTimings` / `useWeatherData` was tightened so each failure mode names the missing field and the fix.

2. **`feat(settings)` — seed default settings and prayer_times row together for new accounts.** New `getOrCreatePrayerAdjustments` mirrors `getOrCreateSettings`; the latter now calls it alongside `createDefaultSettings` so a fresh account ends up with both rows populated. Prayer Timings page switched to the create-aware variant too.

3. **`fix(prayer-timings)` — treat zero-valued calc method and juristic school as configured.** `JuristicSchool.Shafi === 0` and `CalculationMethod.Shia_Ithna_Ashari === 0` are valid settings, but the loader guards used `!settings.juristic_school`, which flagged them as missing and rendered the empty state. Swapped to `isNullOrUndefined`.

4. **`fix(display)` — keep rendering prayer slide when prayer_times row is missing.** `PrayerTimingDisplay` was returning `null` when the `prayerTimeSettings` prop was null, which produced a white swiper slide. The adjustment utilities already fall back to a default no-op adjustment, so the null guard on `prayerTimeSettings` is dropped and `getProcessedPrayerTimings` now accepts `PrayerTimes | null`.

## Test plan
- [ ] Create a brand-new account. Visit `/admin/settings/prayer-times` — the `settings` and `prayer_times` rows should exist in the DB with `calculation_method=3`, `juristic_school=0`.
- [ ] On an account with `juristic_school=0` (Shafi) saved, load `/admin/prayer-timings` — the table should render, not the "Please configure…" empty state.
- [ ] Create a display screen with `show_prayer_times=false` on an account that has no prayer-calc settings — display should not show the "Prayer time settings are missing" warning, and any non-prayer content should still render.
- [ ] Create a display screen with prayer times enabled but no `prayer_times` row saved — the prayer slide should render with default (unadjusted) timings instead of a blank white slide.
- [ ] Trigger each warning path (missing lat/long, missing calc method/school, weather fetch failure) to confirm the new error copy identifies the specific missing field.