### PR TITLE
Cache weather forecasts and keep last-known data on API failure

### DIFF
--- a/src/hooks/useWeatherData.ts
+++ b/src/hooks/useWeatherData.ts
@@ -3,7 +3,12 @@ import { fetchWeatherForecast } from '@/api';
 import type { WeatherForecast } from '@/types';
 import type { ErrorMessage } from '@/components/display';
 import { useDisplayStore } from '@/store';
-import { parseOpenWeatherForecast, isNullOrUndefined } from '@/utils';
+import {
+  parseOpenWeatherForecast,
+  isNullOrUndefined,
+  readWeatherCache,
+  writeWeatherCache,
+} from '@/utils';
 
 /**
  * Custom hook to fetch and manage weather data
@@ -19,57 +24,60 @@ export function useWeatherData(enabled: boolean = true) {
   const { masjidProfile } = useDisplayStore();
 
   useEffect(() => {
+    if (!enabled) return;
+
+    const { latitude, longitude } = masjidProfile || {};
+
+    if (isNullOrUndefined(latitude) || isNullOrUndefined(longitude)) {
+      setErrorMessage({
+        title: 'Masjid location is missing',
+        description:
+          'Weather requires latitude and longitude from the masjid profile. Please set the location in the admin panel, or disable weather on this screen.',
+      });
+      return;
+    }
+
     const abortController = new AbortController();
 
-    async function getWeatherData(signal: AbortSignal) {
-      const { latitude, longitude } = masjidProfile || {};
+    // Hydrate from cache so the slide can render before the network call resolves.
+    // If the API later fails, the user keeps seeing this stale-but-valid forecast.
+    const cached = readWeatherCache(latitude, longitude);
+    const hadCachedData = cached !== null;
+    if (cached) setWeatherForecast(parseOpenWeatherForecast(cached));
 
-      if (isNullOrUndefined(latitude) || isNullOrUndefined(longitude)) {
-        setErrorMessage({
-          title: 'Masjid location is missing',
-          description:
-            'Weather requires latitude and longitude from the masjid profile. Please set the location in the admin panel, or disable weather on this screen.',
-        });
-        return;
-      }
-
-      setIsLoading(true);
+    async function getWeatherData(
+      lat: number,
+      lon: number,
+      signal: AbortSignal,
+      showSpinner: boolean
+    ) {
+      if (showSpinner) setIsLoading(true);
       setErrorMessage(null);
 
       try {
-        const data = await fetchWeatherForecast({ lat: latitude, lon: longitude, signal });
+        const data = await fetchWeatherForecast({ lat, lon, signal });
         if (data) {
           setWeatherForecast(parseOpenWeatherForecast(data));
-        } else {
-          setErrorMessage({
-            title: 'Unable to fetch weather data',
-            description: 'Weather service returned no data. Please try again later.',
-          });
+          writeWeatherCache(lat, lon, data);
         }
       } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError') {
-          console.log('Weather fetch aborted');
-        } else {
-          setErrorMessage({
-            title: 'Failed to load weather data',
-            description:
-              'Unable to connect to weather service. Please check your internet connection and try again.',
-          });
-        }
+        if (error instanceof DOMException && error.name === 'AbortError') return;
+        // Keep whatever forecast is already on screen (cached or last successful fetch).
+        // If nothing has ever loaded, weatherForecast stays null and the consumer
+        // simply omits the weather slide from the slideshow.
+        console.error('Failed to fetch weather data', error);
       } finally {
-        setIsLoading(false);
+        if (showSpinner) setIsLoading(false);
       }
     }
 
-    if (!enabled) return () => abortController.abort();
-
-    getWeatherData(abortController.signal);
+    getWeatherData(latitude, longitude, abortController.signal, !hadCachedData);
 
     // Refresh weather data every 30 minutes
     const interval = setInterval(
       () => {
         if (!abortController.signal.aborted) {
-          getWeatherData(abortController.signal);
+          getWeatherData(latitude, longitude, abortController.signal, false);
         }
       },
       30 * 60 * 1000

--- a/src/utils/weather.ts
+++ b/src/utils/weather.ts
@@ -5,6 +5,39 @@ import type {
   WeatherForecast,
 } from '@/types';
 
+const WEATHER_CACHE_KEY = 'weather_forecast_cache_v1';
+
+type WeatherCacheEntry = {
+  lat: number;
+  lon: number;
+  data: OpenWeatherForecastResponse;
+};
+
+export const readWeatherCache = (lat: number, lon: number): OpenWeatherForecastResponse | null => {
+  try {
+    const raw = localStorage.getItem(WEATHER_CACHE_KEY);
+    if (!raw) return null;
+    const entry = JSON.parse(raw) as WeatherCacheEntry;
+    if (entry.lat !== lat || entry.lon !== lon) return null;
+    return entry.data;
+  } catch {
+    return null;
+  }
+};
+
+export const writeWeatherCache = (
+  lat: number,
+  lon: number,
+  data: OpenWeatherForecastResponse
+): void => {
+  try {
+    const entry: WeatherCacheEntry = { lat, lon, data };
+    localStorage.setItem(WEATHER_CACHE_KEY, JSON.stringify(entry));
+  } catch {
+    // Ignore quota / serialization errors — cache is best-effort.
+  }
+};
+
 export const parseOpenWeatherForecast = (data: OpenWeatherForecastResponse): WeatherForecast => {
   // Get current weather from the first forecast item (most recent)
   const currentItem = data.list[0];


### PR DESCRIPTION
## Summary
- Persist OpenWeather responses in localStorage (keyed by lat/lon) so the weather slide can render from cache before the network call resolves.
- On API failure, keep showing whatever forecast is already on screen (cached or last successful fetch) instead of surfacing a full-page `ErrorDisplay`.
- If the very first fetch fails with no cache, the weather slide is omitted from the slideshow rather than blocking the entire display.

## Test plan
- [ ] First load with no cache: weather slide appears after fetch.
- [ ] Reload with cache: weather slide renders immediately, no spinner.
- [ ] Block `api.openweathermap.org` in devtools and reload: cached forecast continues to display; no error screen.
- [ ] Clear localStorage and block the API: weather slide is absent from the slideshow but other slides (prayer times, content) render normally.
- [ ] Change masjid lat/lon: cache from prior location is ignored; fresh fetch occurs.
- [ ] Disable weather on the screen: hook is a no-op, no fetch, no cache writes.