### PR TITLE
Offline-capable display + realtime admin updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,8 @@
         "tw-animate-css": "^1.2.9",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
-        "vite": "^6.3.5"
+        "vite": "^6.3.5",
+        "vite-plugin-pwa": "^1.3.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -103,6 +104,23 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apideck/better-ajv-errors": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.7.tgz",
+      "integrity": "sha512-TajUJwGWbDwkCx/CZi7tRE8PVB7simCvKJfHUsSdvps+aTM/PDPP4gkLmKnc+x3CE//y9i/nj74GqdL/hwk7Iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonpointer": "^5.0.1",
+        "leven": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "ajv": ">=8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1593,6 +1611,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -3722,6 +3750,16 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -5257,261 +5295,484 @@
         "react-dom": "^19.0.0"
       }
     },
+    "node_modules/@rollup/plugin-babel": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.1.0.tgz",
+      "integrity": "sha512-dFZNuFD2YRcoomP4oYf+DvQNSUA9ih+A3vUqopQx5EdtPGo3WBnQcI/S8pwpz91UsGfL0HsMSOlaMld8HrbubA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.18.6",
+        "@rollup/pluginutils": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "@types/babel__core": "^7.1.9",
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/babel__core": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+      "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+      "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz",
+      "integrity": "sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "serialize-javascript": "^7.0.3",
+        "smob": "^1.0.0",
+        "terser": "^5.17.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.2.tgz",
-      "integrity": "sha512-JkdNEq+DFxZfUwxvB58tHMHBHVgX23ew41g1OQinthJ+ryhdRk67O31S7sYw8u2lTjHUPFxwar07BBt1KHp/hg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.40.2.tgz",
-      "integrity": "sha512-13unNoZ8NzUmnndhPTkWPWbX3vtHodYmy+I9kuLxN+F+l+x3LdVF7UCu8TWVMt1POHLh6oDHhnOA04n8oJZhBw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.2.tgz",
-      "integrity": "sha512-Gzf1Hn2Aoe8VZzevHostPX23U7N5+4D36WJNHK88NZHCJr7aVMG4fadqkIf72eqVPGjGc0HJHNuUaUcxiR+N/w==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.40.2.tgz",
-      "integrity": "sha512-47N4hxa01a4x6XnJoskMKTS8XZ0CZMd8YTbINbi+w03A2w4j1RTlnGHOz/P0+Bg1LaVL6ufZyNprSg+fW5nYQQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.40.2.tgz",
-      "integrity": "sha512-8t6aL4MD+rXSHHZUR1z19+9OFJ2rl1wGKvckN47XFRVO+QL/dUSpKA2SLRo4vMg7ELA8pzGpC+W9OEd1Z/ZqoQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.40.2.tgz",
-      "integrity": "sha512-C+AyHBzfpsOEYRFjztcYUFsH4S7UsE9cDtHCtma5BK8+ydOZYgMmWg1d/4KBytQspJCld8ZIujFMAdKG1xyr4Q==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.40.2.tgz",
-      "integrity": "sha512-de6TFZYIvJwRNjmW3+gaXiZ2DaWL5D5yGmSYzkdzjBDS3W+B9JQ48oZEsmMvemqjtAFzE16DIBLqd6IQQRuG9Q==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.40.2.tgz",
-      "integrity": "sha512-urjaEZubdIkacKc930hUDOfQPysezKla/O9qV+O89enqsqUmQm8Xj8O/vh0gHg4LYfv7Y7UsE3QjzLQzDYN1qg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.40.2.tgz",
-      "integrity": "sha512-KlE8IC0HFOC33taNt1zR8qNlBYHj31qGT1UqWqtvR/+NuCVhfufAq9fxO8BMFC22Wu0rxOwGVWxtCMvZVLmhQg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.40.2.tgz",
-      "integrity": "sha512-j8CgxvfM0kbnhu4XgjnCWJQyyBOeBI1Zq91Z850aUddUmPeQvuAy6OiMdPS46gNFgy8gN1xkYyLgwLYZG3rBOg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.40.2.tgz",
-      "integrity": "sha512-Ybc/1qUampKuRF4tQXc7G7QY9YRyeVSykfK36Y5Qc5dmrIxwFhrOzqaVTNoZygqZ1ZieSWTibfFhQ5qK8jpWxw==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.40.2.tgz",
-      "integrity": "sha512-3FCIrnrt03CCsZqSYAOW/k9n625pjpuMzVfeI+ZBUSDT3MVIFDSPfSUgIl9FqUftxcUXInvFah79hE1c9abD+Q==",
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.40.2.tgz",
-      "integrity": "sha512-QNU7BFHEvHMp2ESSY3SozIkBPaPBDTsfVNGx3Xhv+TdvWXFGOSH2NJvhD1zKAT6AyuuErJgbdvaJhYVhVqrWTg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.40.2.tgz",
-      "integrity": "sha512-5W6vNYkhgfh7URiXTO1E9a0cy4fSgfE4+Hl5agb/U1sa0kjOLMLC1wObxwKxecE17j0URxuTrYZZME4/VH57Hg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.40.2.tgz",
-      "integrity": "sha512-B7LKIz+0+p348JoAL4X/YxGx9zOx3sR+o6Hj15Y3aaApNfAshK8+mWZEf759DXfRLeL2vg5LYJBB7DdcleYCoQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.2.tgz",
-      "integrity": "sha512-lG7Xa+BmBNwpjmVUbmyKxdQJ3Q6whHjMjzQplOs5Z+Gj7mxPtWakGHqzMqNER68G67kmCX9qX57aRsW5V0VOng==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.40.2.tgz",
-      "integrity": "sha512-tD46wKHd+KJvsmije4bUskNuvWKFcTOIM9tZ/RrmIvcXnbi0YK/cKS9FzFtAm7Oxi2EhV5N2OpfFB348vSQRXA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.40.2.tgz",
-      "integrity": "sha512-Bjv/HG8RRWLNkXwQQemdsWw4Mg+IJ29LK+bJPW2SCzPKOUaMmPEppQlu/Fqk1d7+DX3V7JbFdbkh/NMmurT6Pg==",
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.40.2.tgz",
-      "integrity": "sha512-dt1llVSGEsGKvzeIO76HToiYPNPYPkmjhMHhP00T9S4rDern8P2ZWvWAQUEJ+R1UdMWJ/42i/QqJ2WV765GZcA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.40.2.tgz",
-      "integrity": "sha512-bwspbWB04XJpeElvsp+DCylKfF4trJDa2Y9Go8O6A7YLX2LIKGcNK/CYImJN6ZP4DcuOHB4Utl3iCbnR62DudA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -6352,6 +6613,22 @@
         "vite": "^5.2.0 || ^6"
       }
     },
+    "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {
+      "version": "3.0.0-pre1",
+      "resolved": "https://registry.npmjs.org/@trickfilm400/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-3.0.0-pre1.tgz",
+      "integrity": "sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ejs": "^3.1.10",
+        "json5": "^2.2.3",
+        "magic-string": "^0.30.21",
+        "string.prototype.matchall": "^4.0.12"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -6394,10 +6671,11 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-      "dev": true
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
@@ -6480,6 +6758,20 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -7048,6 +7340,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -7055,6 +7354,16 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/attr-accept": {
@@ -7577,6 +7886,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -7890,6 +8209,16 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -8029,6 +8358,22 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true
+    },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -8671,6 +9016,13 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -8678,6 +9030,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eta": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-4.6.0.tgz",
+      "integrity": "sha512-lW6is4T1NFOYnmqGZIfvixqj7A7sSvScF+DN8EK6K58xI5MZ5UvYe0GjopxOXQtZvUn4eDdVuZ8XSoYWTMEKwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/bgub/eta?sponsor=1"
       }
     },
     "node_modules/etag": {
@@ -8861,6 +9226,23 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -8890,6 +9272,39 @@
       },
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/filelist": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/fill-range": {
@@ -8970,6 +9385,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -9000,6 +9432,22 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/fs.realpath": {
@@ -9111,6 +9559,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/get-own-enumerable-property-symbols": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
@@ -9409,6 +9864,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -9698,6 +10160,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -9720,6 +10189,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-path-cwd": {
@@ -9771,6 +10250,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-set": {
@@ -9931,6 +10420,40 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.6",
+        "filelist": "^1.0.4",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -10005,6 +10528,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -10052,6 +10598,16 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -10406,6 +10962,13 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/log-update": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
@@ -10634,6 +11197,16 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -10961,6 +11534,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -11030,6 +11610,33 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "8.2.0",
@@ -11878,6 +12485,19 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-bytes": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
+      "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -12287,6 +12907,16 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -12364,12 +12994,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.40.2.tgz",
-      "integrity": "sha512-tfUOg6DTP4rhQ3VjOO6B4wyrJnGOX85requAXvqYTHsOgb2TFJdZ3aWpT8W2kPoypSGP7dZUyzxJ9ee4buM5Fg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.7"
+        "@types/estree": "1.0.8"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -12379,26 +13010,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.40.2",
-        "@rollup/rollup-android-arm64": "4.40.2",
-        "@rollup/rollup-darwin-arm64": "4.40.2",
-        "@rollup/rollup-darwin-x64": "4.40.2",
-        "@rollup/rollup-freebsd-arm64": "4.40.2",
-        "@rollup/rollup-freebsd-x64": "4.40.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.40.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.40.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.40.2",
-        "@rollup/rollup-linux-arm64-musl": "4.40.2",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.40.2",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.40.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.40.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.40.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.40.2",
-        "@rollup/rollup-linux-x64-gnu": "4.40.2",
-        "@rollup/rollup-linux-x64-musl": "4.40.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.40.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.40.2",
-        "@rollup/rollup-win32-x64-msvc": "4.40.2",
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
         "fsevents": "~2.3.2"
       }
     },
@@ -12552,6 +13188,16 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-static": {
@@ -12764,6 +13410,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/smob": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.1.tgz",
+      "integrity": "sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/sonner": {
@@ -13000,6 +13656,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -13022,6 +13693,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
+      "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/strip-final-newline": {
@@ -13539,6 +14220,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -13546,6 +14237,17 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/upath": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -13729,6 +14431,37 @@
         }
       }
     },
+    "node_modules/vite-plugin-pwa": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-1.3.0.tgz",
+      "integrity": "sha512-c5kMgN+ITrOtHXp8PAtk2uOIEea6XjP/unCGxOWWBzQ6qa65qj/awHg0wf+QF9E/2u9vh86LqxPwzEPNbM2r5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.6",
+        "pretty-bytes": "^6.1.1",
+        "tinyglobby": "^0.2.10",
+        "workbox-build": "^7.4.1",
+        "workbox-window": "^7.4.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vite-pwa/assets-generator": "^1.0.0",
+        "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "workbox-build": "^7.4.1",
+        "workbox-window": "^7.4.1"
+      },
+      "peerDependenciesMeta": {
+        "@vite-pwa/assets-generator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.4.4",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
@@ -13875,6 +14608,389 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/workbox-background-sync": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-7.4.1.tgz",
+      "integrity": "sha512-HhT7KE8tOWDm02wRNshXUnUPofMlhenF2DBdUnDPOubhizzPeItkYTmAB6td1Z2cjYPa98vzEiPLEuzn5hN66g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "idb": "^7.0.1",
+        "workbox-core": "7.4.1"
+      }
+    },
+    "node_modules/workbox-broadcast-update": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-7.4.1.tgz",
+      "integrity": "sha512-uAlgslKLvbQY+suirIdnBCSYrcgBhjp81Nj4l1lj/Jmj0MJO2CJERnCJjT0GFVwmReV0N+zs78K6gqd5gr9/+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.1"
+      }
+    },
+    "node_modules/workbox-build": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-7.4.1.tgz",
+      "integrity": "sha512-SDhxIvEAde9Gy/5w4Yo1Jh/M49Z0qE3q0oteyE8zGq0DScxFqVBcCtIXFuLtmtxRQZCMbf0prco4VyEu3KBQuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apideck/better-ajv-errors": "^0.3.1",
+        "@babel/core": "^7.24.4",
+        "@babel/preset-env": "^7.11.0",
+        "@babel/runtime": "^7.11.2",
+        "@rollup/plugin-babel": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^16.0.3",
+        "@rollup/plugin-replace": "^6.0.3",
+        "@rollup/plugin-terser": "^1.0.0",
+        "@trickfilm400/rollup-plugin-off-main-thread": "^3.0.0-pre1",
+        "ajv": "^8.6.0",
+        "common-tags": "^1.8.0",
+        "eta": "^4.5.1",
+        "fast-json-stable-stringify": "^2.1.0",
+        "fs-extra": "^9.0.1",
+        "glob": "^11.0.1",
+        "pretty-bytes": "^5.3.0",
+        "rollup": "^4.53.3",
+        "source-map": "^0.8.0-beta.0",
+        "stringify-object": "^3.3.0",
+        "strip-comments": "^2.0.1",
+        "tempy": "^0.6.0",
+        "upath": "^1.2.0",
+        "workbox-background-sync": "7.4.1",
+        "workbox-broadcast-update": "7.4.1",
+        "workbox-cacheable-response": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-expiration": "7.4.1",
+        "workbox-google-analytics": "7.4.1",
+        "workbox-navigation-preload": "7.4.1",
+        "workbox-precaching": "7.4.1",
+        "workbox-range-requests": "7.4.1",
+        "workbox-recipes": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1",
+        "workbox-streams": "7.4.1",
+        "workbox-sw": "7.4.1",
+        "workbox-window": "7.4.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/workbox-build/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/workbox-build/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/workbox-build/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/workbox-build/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/workbox-build/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/workbox-build/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/workbox-build/node_modules/pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/workbox-build/node_modules/source-map": {
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+      "deprecated": "The work that was done in this beta branch won't be included in future versions",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "whatwg-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/workbox-build/node_modules/tempy": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.6.0.tgz",
+      "integrity": "sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-stream": "^2.0.0",
+        "temp-dir": "^2.0.0",
+        "type-fest": "^0.16.0",
+        "unique-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/workbox-build/node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/workbox-build/node_modules/type-fest": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+      "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/workbox-build/node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/workbox-build/node_modules/whatwg-url": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/workbox-cacheable-response": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-7.4.1.tgz",
+      "integrity": "sha512-8xaFoJdDc2OjrlbbL3gEeBO1WKcMwRqwLRupgqahYXu75yXajPLuwrbXMrIGZuWYXrQwk0xDjOxZ/ujCy/oJYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.1"
+      }
+    },
+    "node_modules/workbox-core": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.4.1.tgz",
+      "integrity": "sha512-DT+vu46eh/2vRsSHTY4Xmc32Z1rr9PRlQUXr1Dx30ZuXRWwOsvZgGgcwxcasubQLQmbTNYZjv44LkBAQ4tT5tQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/workbox-expiration": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-7.4.1.tgz",
+      "integrity": "sha512-lRKUF7b+OGbeXkQk1s6MHXOa3d7Xxf7Of31W6c6hCfipfIyrtdWZ89stq21AHZMaoG7VNFoHply4Ox+rU31TWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "idb": "^7.0.1",
+        "workbox-core": "7.4.1"
+      }
+    },
+    "node_modules/workbox-google-analytics": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-7.4.1.tgz",
+      "integrity": "sha512-Mks1JwLEt++ZAkF6sS1OpSh9RtAMIsiDgRpK+codiHGIPXeaUOgi4cPc3GFadUl8V5QPeypEk8Oxgl3HlwVzHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-background-sync": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
+      }
+    },
+    "node_modules/workbox-navigation-preload": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-7.4.1.tgz",
+      "integrity": "sha512-C4KVsjPcYKJOhr631AxR9XoG2rLF3QiTk5aMv36MXOjtWvm8axwNFAtKUPGsWUwLXXAMgYM1En7fsvndaXeXRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.1"
+      }
+    },
+    "node_modules/workbox-precaching": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-7.4.1.tgz",
+      "integrity": "sha512-cdr/9qByww7yzEp7zg/qI4ukUrrNjQLgN+ONQRpjy/VqGQXwkgHwr00KksGJK8v0VifwDXBb8a4cWNZH71jn3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
+      }
+    },
+    "node_modules/workbox-range-requests": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-7.4.1.tgz",
+      "integrity": "sha512-7i2oxAUE82gHdAJBCAQ04JzNOdRPqzuOzGfoUyJpFSmeqBNYGPrAH8GPoPjUQTfp+NycwrD2H68VtuF8qxv0vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.1"
+      }
+    },
+    "node_modules/workbox-recipes": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-7.4.1.tgz",
+      "integrity": "sha512-gnbVfmV4/TtmQaM4x9AtuXhcdstJsep3XMVeztOrQVPT+R6+6DeBjGTCQ7fFCXm+4GEHUA5VEBTyi5+4gWGeog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-cacheable-response": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-expiration": "7.4.1",
+        "workbox-precaching": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
+      }
+    },
+    "node_modules/workbox-routing": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-7.4.1.tgz",
+      "integrity": "sha512-yubJGErZOusuidAenaL5ypfhQOa7urxP/f8E0ws7FPb4039RiWXUWBAyUkmUoOL/BcQGen3h0J8872d51IYxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.1"
+      }
+    },
+    "node_modules/workbox-strategies": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-7.4.1.tgz",
+      "integrity": "sha512-GZxpaw9NbmOelj7667uZ2kpk5BFpOGbO4X0qjwh5ls8XQ8C+Lha5LQchTiUzsTFSS+NlUpftYAyOVXvQUrcqOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.1"
+      }
+    },
+    "node_modules/workbox-streams": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-7.4.1.tgz",
+      "integrity": "sha512-HWWtraKUbJknd9kgqGcpQ3G114HOPYvqs8HaJMDs2ebLNAimDkVDaWfAXE6Ybl+m8U6KsCE6pWyLYuigWmnAXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1"
+      }
+    },
+    "node_modules/workbox-sw": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-7.4.1.tgz",
+      "integrity": "sha512-fez5f2DUlDJWTFYkCWQpY10N8gtztd849NswCbVFk0QlcSM4HT5A8x4g4ii650yem4I8tHY0R7JZahwp3ltIPw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/workbox-window": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-7.4.1.tgz",
+      "integrity": "sha512-notZDH2u8VXaqyuD7xaqIfEFi6SRM4SUSd7ewe9PDsVqADuepxX2ZMY3uvuZGxzY5ZOsGC/vD3A/3smFtJt4/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2",
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "tw-animate-css": "^1.2.9",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vite-plugin-pwa": "^1.3.0"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -11,3 +11,4 @@ export * from './useSettings';
 export * from './useLocationSearch';
 export * from './useOrientationMismatch';
 export * from './useWakeLock';
+export * from './useOnlineStatus';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -12,3 +12,4 @@ export * from './useLocationSearch';
 export * from './useOrientationMismatch';
 export * from './useWakeLock';
 export * from './useOnlineStatus';
+export * from './useRealtimeRefresh';

--- a/src/hooks/useFetchDisplayData.ts
+++ b/src/hooks/useFetchDisplayData.ts
@@ -9,11 +9,12 @@ import {
   type AyatAndHadith,
 } from '@/types';
 import { useDisplayStore } from '@/store';
-import {
+import supabase, {
+  fetchContentByTableAndIds,
+  getMasjidProfileByMasjidId,
+  getScreenById,
   getSettings,
   getVisibleScreenContent,
-  fetchContentByTableAndIds,
-  getScreenById,
 } from '@/lib/supabase';
 import type { ErrorMessage } from '@/components/display';
 import { readDisplayCache, writeDisplayCache, type DisplayDataCache } from '@/utils';
@@ -43,6 +44,10 @@ type ContentRecord = (Announcement | Event | Post | YouTubeVideo | AyatAndHadith
   id: string;
 };
 
+// Coalesce bursts of realtime events (e.g. reordering many rows fires one event
+// per row) into a single refetch.
+const REALTIME_DEBOUNCE_MS = 250;
+
 const buildOrderedContent = (
   screenContentRows: DisplayDataCache['screenContent'],
   contentItems: DisplayDataCache['contentItems']
@@ -68,14 +73,19 @@ const buildOrderedContent = (
  * Hydrates from localStorage cache so the screen renders offline. The network
  * fetch runs in the background; on success the cache is updated, on failure
  * the cached data keeps showing.
+ *
+ * Subscribes to Supabase Realtime so admin edits (content, screen settings,
+ * profile, prayer settings) propagate to the display without a reload.
  */
 export function useFetchDisplayData(): ReturnType {
   const [fetching, setFetching] = useState<boolean>(false);
   const [errorMessage, setErrorMessage] = useState<ErrorMessage | null>(null);
   const [orderedContent, setOrderedContent] = useState<DisplayContentItem[]>([]);
   const [userSettings, setUserSettings] = useState<Settings | null>(null);
+  const [refreshKey, setRefreshKey] = useState<number>(0);
 
-  const { masjidProfile, displayScreen, setDisplayScreen, signOut } = useDisplayStore();
+  const { masjidProfile, displayScreen, setDisplayScreen, setMasjidProfile, signOut } =
+    useDisplayStore();
   const masjidId = masjidProfile?.id;
   const screenId = displayScreen?.id;
 
@@ -84,34 +94,38 @@ export function useFetchDisplayData(): ReturnType {
 
     if (!masjidId || !screenId) return () => abortController.abort();
 
+    const isInitialFetch = refreshKey === 0;
     let hasCachedData = false;
-    const cached = readDisplayCache(screenId);
-    if (cached) {
-      hasCachedData = true;
-      setUserSettings(cached.settings);
-      setOrderedContent(buildOrderedContent(cached.screenContent, cached.contentItems));
-      setDisplayScreen(cached.screen);
+
+    if (isInitialFetch) {
+      const cached = readDisplayCache(screenId);
+      if (cached) {
+        hasCachedData = true;
+        setUserSettings(cached.settings);
+        setOrderedContent(buildOrderedContent(cached.screenContent, cached.contentItems));
+        setDisplayScreen(cached.screen);
+      }
     }
 
     const req = async () => {
-      if (!hasCachedData) setFetching(true);
+      if (isInitialFetch && !hasCachedData) setFetching(true);
       setErrorMessage(null);
 
       try {
-        const [settings, screenContentRows, latestScreen] = await Promise.all([
+        const [settings, screenContentRows, latestScreen, latestProfile] = await Promise.all([
           getSettings(masjidId),
           getVisibleScreenContent(screenId),
           getScreenById(screenId),
+          getMasjidProfileByMasjidId(masjidId),
         ]);
 
-        // If screen was deleted, sign out so the display redirects to login
         if (!latestScreen) {
           signOut();
           return;
         }
 
-        // Update screen settings in store if changed
         setDisplayScreen(latestScreen);
+        if (latestProfile) setMasjidProfile(latestProfile);
 
         if (!settings && latestScreen.show_prayer_times) {
           setErrorMessage({
@@ -155,8 +169,7 @@ export function useFetchDisplayData(): ReturnType {
       } catch (error) {
         if (error instanceof DOMException && error.name === 'AbortError') return;
         console.error('Error fetching data:', error);
-        // Keep showing cached data if we have it; otherwise surface a soft error.
-        if (!hasCachedData) {
+        if (isInitialFetch && !hasCachedData) {
           setErrorMessage({
             title: 'Unable to load display content',
             description:
@@ -171,6 +184,94 @@ export function useFetchDisplayData(): ReturnType {
 
     return () => {
       abortController.abort();
+    };
+  }, [masjidId, screenId, refreshKey]);
+
+  // Realtime subscription: bump refreshKey whenever any source table the
+  // display depends on changes for this masjid/screen.
+  useEffect(() => {
+    if (!masjidId || !screenId) return;
+
+    let debounceTimer = 0;
+    const scheduleRefresh = () => {
+      window.clearTimeout(debounceTimer);
+      debounceTimer = window.setTimeout(() => {
+        setRefreshKey(k => k + 1);
+      }, REALTIME_DEBOUNCE_MS);
+    };
+
+    const channel = supabase
+      .channel(`display:${screenId}`)
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'display_screens', filter: `id=eq.${screenId}` },
+        scheduleRefresh
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'screen_content',
+          filter: `screen_id=eq.${screenId}`,
+        },
+        scheduleRefresh
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'settings', filter: `masjid_id=eq.${masjidId}` },
+        scheduleRefresh
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'masjid_profiles', filter: `id=eq.${masjidId}` },
+        scheduleRefresh
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'announcements',
+          filter: `masjid_id=eq.${masjidId}`,
+        },
+        scheduleRefresh
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'events', filter: `masjid_id=eq.${masjidId}` },
+        scheduleRefresh
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'posts', filter: `masjid_id=eq.${masjidId}` },
+        scheduleRefresh
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'youtube_videos',
+          filter: `masjid_id=eq.${masjidId}`,
+        },
+        scheduleRefresh
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'ayat_and_hadith',
+          filter: `masjid_id=eq.${masjidId}`,
+        },
+        scheduleRefresh
+      )
+      .subscribe();
+
+    return () => {
+      window.clearTimeout(debounceTimer);
+      supabase.removeChannel(channel);
     };
   }, [masjidId, screenId]);
 

--- a/src/hooks/useFetchDisplayData.ts
+++ b/src/hooks/useFetchDisplayData.ts
@@ -15,8 +15,8 @@ import {
   fetchContentByTableAndIds,
   getScreenById,
 } from '@/lib/supabase';
-import { toast } from 'sonner';
 import type { ErrorMessage } from '@/components/display';
+import { readDisplayCache, writeDisplayCache, type DisplayDataCache } from '@/utils';
 
 export type DisplayContentItem = {
   contentType: ScreenContentType;
@@ -39,9 +39,35 @@ const TABLE_MAP: Record<string, string> = {
   ayat_and_hadith: 'ayat_and_hadith',
 };
 
+type ContentRecord = (Announcement | Event | Post | YouTubeVideo | AyatAndHadith) & {
+  id: string;
+};
+
+const buildOrderedContent = (
+  screenContentRows: DisplayDataCache['screenContent'],
+  contentItems: DisplayDataCache['contentItems']
+): DisplayContentItem[] => {
+  const items: DisplayContentItem[] = [];
+  for (const row of screenContentRows) {
+    const found = contentItems[row.content_id];
+    if (found) {
+      items.push({
+        contentType: row.content_type as ScreenContentType,
+        displayOrder: row.display_order,
+        data: found,
+      });
+    }
+  }
+  return items;
+};
+
 /**
  * Custom hook to fetch display data filtered by screen content assignments.
  * Only fetches visible content, ordered by display_order.
+ *
+ * Hydrates from localStorage cache so the screen renders offline. The network
+ * fetch runs in the background; on success the cache is updated, on failure
+ * the cached data keeps showing.
  */
 export function useFetchDisplayData(): ReturnType {
   const [fetching, setFetching] = useState<boolean>(false);
@@ -58,8 +84,17 @@ export function useFetchDisplayData(): ReturnType {
 
     if (!masjidId || !screenId) return () => abortController.abort();
 
+    let hasCachedData = false;
+    const cached = readDisplayCache(screenId);
+    if (cached) {
+      hasCachedData = true;
+      setUserSettings(cached.settings);
+      setOrderedContent(buildOrderedContent(cached.screenContent, cached.contentItems));
+      setDisplayScreen(cached.screen);
+    }
+
     const req = async () => {
-      setFetching(true);
+      if (!hasCachedData) setFetching(true);
       setErrorMessage(null);
 
       try {
@@ -89,52 +124,45 @@ export function useFetchDisplayData(): ReturnType {
 
         setUserSettings(settings);
 
-        // Group content IDs by type
         const idsByType: Record<string, string[]> = {};
         for (const row of screenContentRows) {
           if (!idsByType[row.content_type]) idsByType[row.content_type] = [];
           idsByType[row.content_type].push(row.content_id);
         }
 
-        type ContentRecord = (Announcement | Event | Post | AyatAndHadith) & { id: string };
-
-        // Fetch all content in parallel
         const fetchResults = await Promise.all(
           Object.entries(idsByType).map(async ([type, ids]) => {
             const data = await fetchContentByTableAndIds<ContentRecord>(TABLE_MAP[type], ids);
-            const dataMap = new Map<string, ContentRecord>();
-            for (const item of data) {
-              dataMap.set(item.id, item);
-            }
-            return { type, dataMap };
+            return { type, data };
           })
         );
 
-        // Build a lookup: contentId -> fetched data
-        const contentDataMap = new Map<string, ContentRecord>();
-        for (const { dataMap } of fetchResults) {
-          for (const [id, data] of dataMap) {
-            contentDataMap.set(id, data);
+        const contentItems: Record<string, ContentRecord> = {};
+        for (const { data } of fetchResults) {
+          for (const item of data) {
+            contentItems[item.id] = item;
           }
         }
 
-        // Build ordered content list following screen_content display_order
-        const items: DisplayContentItem[] = [];
-        for (const row of screenContentRows) {
-          const found = contentDataMap.get(row.content_id);
-          if (found) {
-            items.push({
-              contentType: row.content_type as ScreenContentType,
-              displayOrder: row.display_order,
-              data: found,
-            });
-          }
-        }
+        setOrderedContent(buildOrderedContent(screenContentRows, contentItems));
 
-        setOrderedContent(items);
+        writeDisplayCache(screenId, {
+          settings,
+          screen: latestScreen,
+          screenContent: screenContentRows,
+          contentItems,
+        });
       } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') return;
         console.error('Error fetching data:', error);
-        toast.error('Failed to fetch data');
+        // Keep showing cached data if we have it; otherwise surface a soft error.
+        if (!hasCachedData) {
+          setErrorMessage({
+            title: 'Unable to load display content',
+            description:
+              'No cached content is available and we could not reach the server. Check the internet connection and refresh.',
+          });
+        }
       } finally {
         setFetching(false);
       }

--- a/src/hooks/useFetchDisplayData.ts
+++ b/src/hooks/useFetchDisplayData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   type Announcement,
   type Event,
@@ -7,17 +7,20 @@ import {
   type Settings,
   type ScreenContentType,
   type AyatAndHadith,
+  SupabaseTables,
 } from '@/types';
 import { useDisplayStore } from '@/store';
-import supabase, {
+import {
   fetchContentByTableAndIds,
   getMasjidProfileByMasjidId,
   getScreenById,
   getSettings,
   getVisibleScreenContent,
+  type TableSubscription,
 } from '@/lib/supabase';
 import type { ErrorMessage } from '@/components/display';
 import { readDisplayCache, writeDisplayCache, type DisplayDataCache } from '@/utils';
+import { useRealtimeRefresh } from './useRealtimeRefresh';
 
 export type DisplayContentItem = {
   contentType: ScreenContentType;
@@ -43,10 +46,6 @@ const TABLE_MAP: Record<string, string> = {
 type ContentRecord = (Announcement | Event | Post | YouTubeVideo | AyatAndHadith) & {
   id: string;
 };
-
-// Coalesce bursts of realtime events (e.g. reordering many rows fires one event
-// per row) into a single refetch.
-const REALTIME_DEBOUNCE_MS = 250;
 
 const buildOrderedContent = (
   screenContentRows: DisplayDataCache['screenContent'],
@@ -82,12 +81,32 @@ export function useFetchDisplayData(): ReturnType {
   const [errorMessage, setErrorMessage] = useState<ErrorMessage | null>(null);
   const [orderedContent, setOrderedContent] = useState<DisplayContentItem[]>([]);
   const [userSettings, setUserSettings] = useState<Settings | null>(null);
-  const [refreshKey, setRefreshKey] = useState<number>(0);
 
   const { masjidProfile, displayScreen, setDisplayScreen, setMasjidProfile, signOut } =
     useDisplayStore();
   const masjidId = masjidProfile?.id;
   const screenId = displayScreen?.id;
+
+  const subscriptions = useMemo<TableSubscription[]>(() => {
+    if (!masjidId || !screenId) return [];
+    const masjidFilter = `masjid_id=eq.${masjidId}`;
+    return [
+      { table: SupabaseTables.DisplayScreens, filter: `id=eq.${screenId}` },
+      { table: SupabaseTables.ScreenContent, filter: `screen_id=eq.${screenId}` },
+      { table: SupabaseTables.Settings, filter: masjidFilter },
+      { table: SupabaseTables.MasjidProfiles, filter: `id=eq.${masjidId}` },
+      { table: SupabaseTables.Announcements, filter: masjidFilter },
+      { table: SupabaseTables.Events, filter: masjidFilter },
+      { table: SupabaseTables.Posts, filter: masjidFilter },
+      { table: SupabaseTables.YouTubeVideos, filter: masjidFilter },
+      { table: SupabaseTables.AyatAndHadith, filter: masjidFilter },
+    ];
+  }, [masjidId, screenId]);
+
+  const refreshKey = useRealtimeRefresh(
+    masjidId && screenId ? `display:${screenId}` : null,
+    subscriptions
+  );
 
   useEffect(() => {
     const abortController = new AbortController();
@@ -186,94 +205,6 @@ export function useFetchDisplayData(): ReturnType {
       abortController.abort();
     };
   }, [masjidId, screenId, refreshKey]);
-
-  // Realtime subscription: bump refreshKey whenever any source table the
-  // display depends on changes for this masjid/screen.
-  useEffect(() => {
-    if (!masjidId || !screenId) return;
-
-    let debounceTimer = 0;
-    const scheduleRefresh = () => {
-      window.clearTimeout(debounceTimer);
-      debounceTimer = window.setTimeout(() => {
-        setRefreshKey(k => k + 1);
-      }, REALTIME_DEBOUNCE_MS);
-    };
-
-    const channel = supabase
-      .channel(`display:${screenId}`)
-      .on(
-        'postgres_changes',
-        { event: '*', schema: 'public', table: 'display_screens', filter: `id=eq.${screenId}` },
-        scheduleRefresh
-      )
-      .on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'screen_content',
-          filter: `screen_id=eq.${screenId}`,
-        },
-        scheduleRefresh
-      )
-      .on(
-        'postgres_changes',
-        { event: '*', schema: 'public', table: 'settings', filter: `masjid_id=eq.${masjidId}` },
-        scheduleRefresh
-      )
-      .on(
-        'postgres_changes',
-        { event: '*', schema: 'public', table: 'masjid_profiles', filter: `id=eq.${masjidId}` },
-        scheduleRefresh
-      )
-      .on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'announcements',
-          filter: `masjid_id=eq.${masjidId}`,
-        },
-        scheduleRefresh
-      )
-      .on(
-        'postgres_changes',
-        { event: '*', schema: 'public', table: 'events', filter: `masjid_id=eq.${masjidId}` },
-        scheduleRefresh
-      )
-      .on(
-        'postgres_changes',
-        { event: '*', schema: 'public', table: 'posts', filter: `masjid_id=eq.${masjidId}` },
-        scheduleRefresh
-      )
-      .on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'youtube_videos',
-          filter: `masjid_id=eq.${masjidId}`,
-        },
-        scheduleRefresh
-      )
-      .on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'ayat_and_hadith',
-          filter: `masjid_id=eq.${masjidId}`,
-        },
-        scheduleRefresh
-      )
-      .subscribe();
-
-    return () => {
-      window.clearTimeout(debounceTimer);
-      supabase.removeChannel(channel);
-    };
-  }, [masjidId, screenId]);
 
   return {
     isLoading: fetching,

--- a/src/hooks/useOnlineStatus.ts
+++ b/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import { isOnlineNow } from '@/utils';
+
+/**
+ * Subscribes to the browser's online/offline events and returns the current
+ * connectivity state. Components can use this to gate features that need a
+ * live network connection (YouTube embeds, fresh API calls, etc.).
+ */
+export const useOnlineStatus = (): boolean => {
+  const [online, setOnline] = useState<boolean>(isOnlineNow);
+
+  useEffect(() => {
+    const handleOnline = () => setOnline(true);
+    const handleOffline = () => setOnline(false);
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  return online;
+};

--- a/src/hooks/usePrayerTimings.ts
+++ b/src/hooks/usePrayerTimings.ts
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import type { AlAdhanPrayerTimes, PrayerTimes, Settings } from '@/types';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { type AlAdhanPrayerTimes, type PrayerTimes, type Settings, SupabaseTables } from '@/types';
 import { useDisplayStore } from '@/store';
-import supabase, { getPrayerAdjustments, getSettings } from '@/lib/supabase';
+import { getPrayerAdjustments, getSettings, type TableSubscription } from '@/lib/supabase';
 import { fetchPrayerTimesForThisMonth } from '@/api';
 import {
   findTodayInMonth,
@@ -11,6 +11,7 @@ import {
   writePrayerTimesMonth,
 } from '@/utils';
 import type { ErrorMessage } from '@/components/display';
+import { useRealtimeRefresh } from './useRealtimeRefresh';
 
 type ReturnType = {
   isLoading: boolean;
@@ -25,9 +26,6 @@ const millisecondsUntilNextMidnight = (now: Date): number => {
   return nextMidnight.getTime() - now.getTime();
 };
 
-// Coalesce bursts of realtime events into a single refetch.
-const REALTIME_DEBOUNCE_MS = 250;
-
 /**
  * Custom hook to fetch and manage prayer times and settings.
  *
@@ -41,11 +39,24 @@ export function usePrayerTimings(enabled: boolean = true): ReturnType {
   const [errorMessage, setErrorMessage] = useState<ErrorMessage | null>(null);
   const [prayerTimes, setPrayerTimes] = useState<AlAdhanPrayerTimes | null>(null);
   const [prayerTimeSettings, setPrayerTimeSettings] = useState<PrayerTimes | null>(null);
-  const [refreshKey, setRefreshKey] = useState<number>(0);
   const monthDaysRef = useRef<AlAdhanPrayerTimes[] | null>(null);
 
   const { masjidProfile } = useDisplayStore();
   const masjidId = masjidProfile?.id;
+
+  const subscriptions = useMemo<TableSubscription[]>(() => {
+    if (!masjidId) return [];
+    const masjidFilter = `masjid_id=eq.${masjidId}`;
+    return [
+      { table: SupabaseTables.Settings, filter: masjidFilter },
+      { table: SupabaseTables.PrayerTimes, filter: masjidFilter },
+    ];
+  }, [masjidId]);
+
+  const refreshKey = useRealtimeRefresh(
+    enabled && masjidId ? `prayer-times:${masjidId}` : null,
+    subscriptions
+  );
 
   const fetchPrayerTimes = useCallback(
     async (
@@ -180,39 +191,6 @@ export function usePrayerTimings(enabled: boolean = true): ReturnType {
       abortController.abort();
     };
   }, [enabled, fetchPrayerTimes, masjidId, masjidProfile, refreshKey]);
-
-  // Realtime: re-fetch when calculation settings or prayer adjustments change.
-  // Location changes propagate via the masjidProfile dep above.
-  useEffect(() => {
-    if (!enabled || !masjidId) return;
-
-    let debounceTimer = 0;
-    const scheduleRefresh = () => {
-      window.clearTimeout(debounceTimer);
-      debounceTimer = window.setTimeout(() => {
-        setRefreshKey(k => k + 1);
-      }, REALTIME_DEBOUNCE_MS);
-    };
-
-    const channel = supabase
-      .channel(`prayer-times:${masjidId}`)
-      .on(
-        'postgres_changes',
-        { event: '*', schema: 'public', table: 'settings', filter: `masjid_id=eq.${masjidId}` },
-        scheduleRefresh
-      )
-      .on(
-        'postgres_changes',
-        { event: '*', schema: 'public', table: 'prayer_times', filter: `masjid_id=eq.${masjidId}` },
-        scheduleRefresh
-      )
-      .subscribe();
-
-    return () => {
-      window.clearTimeout(debounceTimer);
-      supabase.removeChannel(channel);
-    };
-  }, [enabled, masjidId]);
 
   // At midnight, re-pick today's row from the cached month so prayer times
   // roll over without a network call. If the month has changed, the cached

--- a/src/hooks/usePrayerTimings.ts
+++ b/src/hooks/usePrayerTimings.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { AlAdhanPrayerTimes, PrayerTimes, Settings } from '@/types';
 import { useDisplayStore } from '@/store';
-import { getPrayerAdjustments, getSettings } from '@/lib/supabase';
+import supabase, { getPrayerAdjustments, getSettings } from '@/lib/supabase';
 import { fetchPrayerTimesForThisMonth } from '@/api';
 import {
   findTodayInMonth,
@@ -25,6 +25,9 @@ const millisecondsUntilNextMidnight = (now: Date): number => {
   return nextMidnight.getTime() - now.getTime();
 };
 
+// Coalesce bursts of realtime events into a single refetch.
+const REALTIME_DEBOUNCE_MS = 250;
+
 /**
  * Custom hook to fetch and manage prayer times and settings.
  *
@@ -38,6 +41,7 @@ export function usePrayerTimings(enabled: boolean = true): ReturnType {
   const [errorMessage, setErrorMessage] = useState<ErrorMessage | null>(null);
   const [prayerTimes, setPrayerTimes] = useState<AlAdhanPrayerTimes | null>(null);
   const [prayerTimeSettings, setPrayerTimeSettings] = useState<PrayerTimes | null>(null);
+  const [refreshKey, setRefreshKey] = useState<number>(0);
   const monthDaysRef = useRef<AlAdhanPrayerTimes[] | null>(null);
 
   const { masjidProfile } = useDisplayStore();
@@ -117,6 +121,7 @@ export function usePrayerTimings(enabled: boolean = true): ReturnType {
 
     if (!enabled || !masjidId) return () => abortController.abort();
 
+    const isInitialFetch = refreshKey === 0;
     let hadCachedMonth = false;
 
     const fetchData = async () => {
@@ -151,13 +156,13 @@ export function usePrayerTimings(enabled: boolean = true): ReturnType {
           }
         }
 
-        if (!hadCachedMonth) setIsLoading(true);
+        if (isInitialFetch && !hadCachedMonth) setIsLoading(true);
 
         await fetchPrayerTimes(userSettings, adjustments, abortController.signal, hadCachedMonth);
       } catch (error) {
         if (error instanceof DOMException && error.name === 'AbortError') return;
         console.error('Error fetching prayer times:', error);
-        if (!hadCachedMonth) {
+        if (isInitialFetch && !hadCachedMonth) {
           setErrorMessage({
             title: 'Unable to load prayer times',
             description:
@@ -174,7 +179,40 @@ export function usePrayerTimings(enabled: boolean = true): ReturnType {
     return () => {
       abortController.abort();
     };
-  }, [enabled, fetchPrayerTimes, masjidId, masjidProfile]);
+  }, [enabled, fetchPrayerTimes, masjidId, masjidProfile, refreshKey]);
+
+  // Realtime: re-fetch when calculation settings or prayer adjustments change.
+  // Location changes propagate via the masjidProfile dep above.
+  useEffect(() => {
+    if (!enabled || !masjidId) return;
+
+    let debounceTimer = 0;
+    const scheduleRefresh = () => {
+      window.clearTimeout(debounceTimer);
+      debounceTimer = window.setTimeout(() => {
+        setRefreshKey(k => k + 1);
+      }, REALTIME_DEBOUNCE_MS);
+    };
+
+    const channel = supabase
+      .channel(`prayer-times:${masjidId}`)
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'settings', filter: `masjid_id=eq.${masjidId}` },
+        scheduleRefresh
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'prayer_times', filter: `masjid_id=eq.${masjidId}` },
+        scheduleRefresh
+      )
+      .subscribe();
+
+    return () => {
+      window.clearTimeout(debounceTimer);
+      supabase.removeChannel(channel);
+    };
+  }, [enabled, masjidId]);
 
   // At midnight, re-pick today's row from the cached month so prayer times
   // roll over without a network call. If the month has changed, the cached

--- a/src/hooks/usePrayerTimings.ts
+++ b/src/hooks/usePrayerTimings.ts
@@ -1,10 +1,15 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { AlAdhanPrayerTimes, PrayerTimes, Settings } from '@/types';
 import { useDisplayStore } from '@/store';
 import { getPrayerAdjustments, getSettings } from '@/lib/supabase';
-import { toast } from 'sonner';
-import { fetchPrayerTimesForDate } from '@/api';
-import { isNullOrUndefined } from '@/utils';
+import { fetchPrayerTimesForThisMonth } from '@/api';
+import {
+  findTodayInMonth,
+  isNullOrUndefined,
+  monthCacheKeyFromDate,
+  readPrayerTimesMonth,
+  writePrayerTimesMonth,
+} from '@/utils';
 import type { ErrorMessage } from '@/components/display';
 
 type ReturnType = {
@@ -14,16 +19,26 @@ type ReturnType = {
   prayerTimeSettings: PrayerTimes | null;
 };
 
+const millisecondsUntilNextMidnight = (now: Date): number => {
+  const nextMidnight = new Date(now);
+  nextMidnight.setHours(24, 0, 5, 0); // 5s past midnight to be safe
+  return nextMidnight.getTime() - now.getTime();
+};
+
 /**
- * Custom hook to fetch and manage prayer times and settings
- * Fetches prayer time settings from database and prayer times from Al-Adhan API
- * @returns Object containing loading state, error messages, prayer times, and settings
+ * Custom hook to fetch and manage prayer times and settings.
+ *
+ * Fetches a full month from Al-Adhan and caches it in localStorage so the
+ * display works offline and survives midnight rollovers without a network call.
+ * On day rollover, re-picks today's row from the cached month. When the month
+ * itself changes, the next render hits the network to fetch the new month.
  */
 export function usePrayerTimings(enabled: boolean = true): ReturnType {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [errorMessage, setErrorMessage] = useState<ErrorMessage | null>(null);
   const [prayerTimes, setPrayerTimes] = useState<AlAdhanPrayerTimes | null>(null);
   const [prayerTimeSettings, setPrayerTimeSettings] = useState<PrayerTimes | null>(null);
+  const monthDaysRef = useRef<AlAdhanPrayerTimes[] | null>(null);
 
   const { masjidProfile } = useDisplayStore();
   const masjidId = masjidProfile?.id;
@@ -31,51 +46,66 @@ export function usePrayerTimings(enabled: boolean = true): ReturnType {
   const fetchPrayerTimes = useCallback(
     async (
       userSettings: Settings | null,
-      prayerTimeSettings: PrayerTimes | null,
-      signal: AbortSignal
+      adjustments: PrayerTimes | null,
+      signal: AbortSignal,
+      hadCachedMonth: boolean
     ) => {
+      const { latitude, longitude } = masjidProfile || {};
+
+      if (isNullOrUndefined(latitude) || isNullOrUndefined(longitude)) {
+        setErrorMessage({
+          title: 'Masjid location is missing',
+          description:
+            'Prayer times need latitude and longitude from the masjid profile. Please set the location in the admin panel, or disable prayer times on this screen.',
+        });
+        return;
+      }
+
+      const method = userSettings?.calculation_method;
+      const school = userSettings?.juristic_school;
+
+      if (isNullOrUndefined(method) || isNullOrUndefined(school)) {
+        setErrorMessage({
+          title: 'Prayer calculation settings are missing',
+          description:
+            'Prayer times require a calculation method and juristic school. Please configure them in the admin panel, or disable prayer times on this screen.',
+        });
+        return;
+      }
+
       try {
-        const { latitude, longitude } = masjidProfile || {};
-
-        if (isNullOrUndefined(latitude) || isNullOrUndefined(longitude)) {
-          setErrorMessage({
-            title: 'Masjid location is missing',
-            description:
-              'Prayer times need latitude and longitude from the masjid profile. Please set the location in the admin panel, or disable prayer times on this screen.',
-          });
-          return;
-        }
-
-        const method = userSettings?.calculation_method;
-        const school = userSettings?.juristic_school;
-
-        if (isNullOrUndefined(method) || isNullOrUndefined(school)) {
-          setErrorMessage({
-            title: 'Prayer calculation settings are missing',
-            description:
-              'Prayer times require a calculation method and juristic school. Please configure them in the admin panel, or disable prayer times on this screen.',
-          });
-          return;
-        }
-
-        const response = await fetchPrayerTimesForDate({
-          date: new Date(),
+        const today = new Date();
+        const response = await fetchPrayerTimesForThisMonth({
+          date: today,
           latitude,
           longitude,
           method,
           school,
           signal,
         });
+
         if (response?.data) {
-          setPrayerTimes(response.data);
-          setPrayerTimeSettings(prayerTimeSettings);
+          monthDaysRef.current = response.data;
+          const todayRow = findTodayInMonth(response.data, today);
+          if (todayRow) setPrayerTimes(todayRow);
+          setPrayerTimeSettings(adjustments);
+
+          writePrayerTimesMonth(
+            monthCacheKeyFromDate(today, latitude, longitude, method, school),
+            response.data
+          );
         }
       } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError') {
-          console.log('Prayer times fetch aborted');
-        } else {
-          console.error('Failed to fetch prayer times', error);
-          toast.error('Failed to fetch prayer times');
+        if (error instanceof DOMException && error.name === 'AbortError') return;
+        // Keep whatever month is already on screen (cached). If we never had any
+        // cached data, surface a soft error so the operator knows what's wrong.
+        console.error('Failed to fetch prayer times', error);
+        if (!hadCachedMonth) {
+          setErrorMessage({
+            title: 'Unable to load prayer times',
+            description:
+              'No cached prayer times are available and we could not reach the server. Check the internet connection.',
+          });
         }
       }
     },
@@ -87,19 +117,53 @@ export function usePrayerTimings(enabled: boolean = true): ReturnType {
 
     if (!enabled || !masjidId) return () => abortController.abort();
 
+    let hadCachedMonth = false;
+
     const fetchData = async () => {
-      setIsLoading(true);
       setErrorMessage(null);
 
       try {
-        const [userSettings, prayerTimeSettings] = await Promise.all([
+        const [userSettings, adjustments] = await Promise.all([
           getSettings(masjidId),
           getPrayerAdjustments(masjidId),
         ]);
-        await fetchPrayerTimes(userSettings, prayerTimeSettings, abortController.signal);
+
+        const { latitude, longitude } = masjidProfile || {};
+        const method = userSettings?.calculation_method;
+        const school = userSettings?.juristic_school;
+
+        if (
+          !isNullOrUndefined(latitude) &&
+          !isNullOrUndefined(longitude) &&
+          !isNullOrUndefined(method) &&
+          !isNullOrUndefined(school)
+        ) {
+          const today = new Date();
+          const cached = readPrayerTimesMonth(
+            monthCacheKeyFromDate(today, latitude, longitude, method, school)
+          );
+          if (cached) {
+            hadCachedMonth = true;
+            monthDaysRef.current = cached;
+            const todayRow = findTodayInMonth(cached, today);
+            if (todayRow) setPrayerTimes(todayRow);
+            setPrayerTimeSettings(adjustments);
+          }
+        }
+
+        if (!hadCachedMonth) setIsLoading(true);
+
+        await fetchPrayerTimes(userSettings, adjustments, abortController.signal, hadCachedMonth);
       } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') return;
         console.error('Error fetching prayer times:', error);
-        toast.error('Failed to fetch prayer times');
+        if (!hadCachedMonth) {
+          setErrorMessage({
+            title: 'Unable to load prayer times',
+            description:
+              'No cached prayer times are available and we could not reach the server. Check the internet connection.',
+          });
+        }
       } finally {
         setIsLoading(false);
       }
@@ -110,7 +174,30 @@ export function usePrayerTimings(enabled: boolean = true): ReturnType {
     return () => {
       abortController.abort();
     };
-  }, [enabled, fetchPrayerTimes, masjidId]);
+  }, [enabled, fetchPrayerTimes, masjidId, masjidProfile]);
+
+  // At midnight, re-pick today's row from the cached month so prayer times
+  // roll over without a network call. If the month has changed, the cached
+  // data won't contain the new day — the next mount/refresh will fetch it.
+  useEffect(() => {
+    if (!enabled) return;
+
+    let timeoutId = 0;
+    const scheduleNext = () => {
+      const delay = millisecondsUntilNextMidnight(new Date());
+      timeoutId = window.setTimeout(() => {
+        const days = monthDaysRef.current;
+        if (days) {
+          const todayRow = findTodayInMonth(days, new Date());
+          if (todayRow) setPrayerTimes(todayRow);
+        }
+        scheduleNext();
+      }, delay);
+    };
+    scheduleNext();
+
+    return () => window.clearTimeout(timeoutId);
+  }, [enabled]);
 
   return {
     isLoading,

--- a/src/hooks/useRealtimeRefresh.ts
+++ b/src/hooks/useRealtimeRefresh.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import { subscribeToTableChanges, type TableSubscription } from '@/lib/supabase';
+
+const DEFAULT_DEBOUNCE_MS = 250;
+
+/**
+ * Subscribes to Supabase Realtime changes on the given tables and returns a
+ * counter that increments whenever any of them changes. Bursts of events
+ * (e.g. reordering many rows) are coalesced into a single bump via debounce.
+ *
+ * Add the returned key to a fetch effect's dependency array to re-run the
+ * fetch on every change. Pass `channelName: null` to disable subscription.
+ */
+export function useRealtimeRefresh(
+  channelName: string | null,
+  subscriptions: TableSubscription[],
+  debounceMs: number = DEFAULT_DEBOUNCE_MS
+): number {
+  const [refreshKey, setRefreshKey] = useState<number>(0);
+
+  // Serialize the subscription list so callers can pass an inline array
+  // without re-subscribing on every render.
+  const signature = JSON.stringify(subscriptions);
+
+  useEffect(() => {
+    if (!channelName) return;
+
+    let timer = 0;
+    const onChange = () => {
+      window.clearTimeout(timer);
+      timer = window.setTimeout(() => {
+        setRefreshKey(k => k + 1);
+      }, debounceMs);
+    };
+
+    const unsubscribe = subscribeToTableChanges(channelName, subscriptions, onChange);
+    return () => {
+      window.clearTimeout(timer);
+      unsubscribe();
+    };
+    // `signature` captures the subscriptions array contents.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [channelName, signature, debounceMs]);
+
+  return refreshKey;
+}

--- a/src/lib/supabase/index.ts
+++ b/src/lib/supabase/index.ts
@@ -9,3 +9,4 @@ export default supabase;
 
 export * from './services';
 export * from './helpers';
+export * from './realtime';

--- a/src/lib/supabase/realtime.ts
+++ b/src/lib/supabase/realtime.ts
@@ -1,0 +1,39 @@
+import supabase from './index';
+import type { SupabaseTables } from '@/types';
+
+export type TableSubscription = {
+  table: SupabaseTables | string;
+  /**
+   * Postgres changes filter, e.g. `id=eq.${id}` or `masjid_id=eq.${masjidId}`.
+   * Omit to receive every row change on the table (RLS still applies).
+   */
+  filter?: string;
+};
+
+/**
+ * Subscribes to row-level changes on one or more tables and fires a single
+ * `onChange` callback for any of them. Returns a cleanup function that
+ * unsubscribes from the channel.
+ *
+ * The channel name must be unique within the page; reuse will silently
+ * replace the previous subscription. Caller is responsible for invoking
+ * the cleanup on unmount.
+ */
+export function subscribeToTableChanges(
+  channelName: string,
+  subscriptions: TableSubscription[],
+  onChange: () => void
+): () => void {
+  const channel = supabase.channel(channelName);
+  for (const sub of subscriptions) {
+    channel.on(
+      'postgres_changes',
+      { event: '*', schema: 'public', table: sub.table, filter: sub.filter },
+      onChange
+    );
+  }
+  channel.subscribe();
+  return () => {
+    supabase.removeChannel(channel);
+  };
+}

--- a/src/pages/app/display.tsx
+++ b/src/pages/app/display.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   useFetchDisplayData,
+  useOnlineStatus,
   useOrientationMismatch,
   usePrayerTimings,
   useWakeLock,
@@ -43,7 +44,24 @@ export default function Display() {
   const showPrayerTimes = displayScreen?.show_prayer_times ?? true;
   const showWeather = displayScreen?.show_weather ?? true;
 
-  const { isLoading, errorMessage, orderedContent, userSettings } = useFetchDisplayData();
+  const isOnline = useOnlineStatus();
+
+  const {
+    isLoading,
+    errorMessage,
+    orderedContent: rawOrderedContent,
+    userSettings,
+  } = useFetchDisplayData();
+
+  // YouTube embeds need a live network connection, so drop those slides when
+  // we're offline — the slideshow keeps cycling through the remaining content.
+  const orderedContent = useMemo(
+    () =>
+      isOnline
+        ? rawOrderedContent
+        : rawOrderedContent.filter(item => item.contentType !== 'youtube_videos'),
+    [rawOrderedContent, isOnline]
+  );
 
   const {
     isLoading: isPrayerTimingsLoading,

--- a/src/utils/display-cache.ts
+++ b/src/utils/display-cache.ts
@@ -1,0 +1,41 @@
+import type {
+  Announcement,
+  AyatAndHadith,
+  DisplayScreen,
+  Event,
+  Post,
+  ScreenContent,
+  Settings,
+  YouTubeVideo,
+} from '@/types';
+
+const DISPLAY_CACHE_PREFIX = 'display_data_cache_v1';
+
+type CachedContentRecord = Announcement | Event | Post | YouTubeVideo | AyatAndHadith;
+
+export type DisplayDataCache = {
+  settings: Settings | null;
+  screen: DisplayScreen;
+  screenContent: ScreenContent[];
+  contentItems: Record<string, CachedContentRecord>;
+};
+
+const cacheKey = (screenId: string) => `${DISPLAY_CACHE_PREFIX}:${screenId}`;
+
+export const readDisplayCache = (screenId: string): DisplayDataCache | null => {
+  try {
+    const raw = localStorage.getItem(cacheKey(screenId));
+    if (!raw) return null;
+    return JSON.parse(raw) as DisplayDataCache;
+  } catch {
+    return null;
+  }
+};
+
+export const writeDisplayCache = (screenId: string, payload: DisplayDataCache): void => {
+  try {
+    localStorage.setItem(cacheKey(screenId), JSON.stringify(payload));
+  } catch {
+    // Ignore quota / serialization errors — cache is best-effort.
+  }
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,6 +6,7 @@ export * from './display';
 export * from './weather-icon-mapping';
 export * from './weather-background-mapping';
 export * from './weather';
+export * from './weather-cache';
 export * from './prayer-card-images';
 export * from './image-validation';
 export * from './password-strength';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,6 +7,7 @@ export * from './weather-icon-mapping';
 export * from './weather-background-mapping';
 export * from './weather';
 export * from './weather-cache';
+export * from './display-cache';
 export * from './prayer-card-images';
 export * from './image-validation';
 export * from './password-strength';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,6 +8,7 @@ export * from './weather-background-mapping';
 export * from './weather';
 export * from './weather-cache';
 export * from './display-cache';
+export * from './prayer-times-cache';
 export * from './prayer-card-images';
 export * from './image-validation';
 export * from './password-strength';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,6 +9,7 @@ export * from './weather';
 export * from './weather-cache';
 export * from './display-cache';
 export * from './prayer-times-cache';
+export * from './online-status';
 export * from './prayer-card-images';
 export * from './image-validation';
 export * from './password-strength';

--- a/src/utils/online-status.ts
+++ b/src/utils/online-status.ts
@@ -1,0 +1,9 @@
+/**
+ * `navigator.onLine` is false only when the OS reports no connection. It is a
+ * best-effort signal — we treat true as "probably online" and false as a
+ * definite "offline".
+ */
+export const isOnlineNow = (): boolean => {
+  if (typeof navigator === 'undefined') return true;
+  return navigator.onLine !== false;
+};

--- a/src/utils/prayer-times-cache.ts
+++ b/src/utils/prayer-times-cache.ts
@@ -1,0 +1,74 @@
+import type { AlAdhanPrayerTimes } from '@/types';
+import { formatDate, getYearAndMonth } from './date-time';
+
+const PRAYER_TIMES_CACHE_PREFIX = 'prayer_times_month_cache_v1';
+
+export type PrayerTimesCacheKey = {
+  latitude: number;
+  longitude: number;
+  method: number;
+  school: number;
+  year: number;
+  month: number;
+};
+
+type PrayerTimesCacheEntry = PrayerTimesCacheKey & {
+  days: AlAdhanPrayerTimes[];
+};
+
+const buildCacheId = (key: PrayerTimesCacheKey): string =>
+  [
+    PRAYER_TIMES_CACHE_PREFIX,
+    key.latitude,
+    key.longitude,
+    key.method,
+    key.school,
+    key.year,
+    key.month,
+  ].join(':');
+
+export const monthCacheKeyFromDate = (
+  date: Date,
+  latitude: number,
+  longitude: number,
+  method: number,
+  school: number
+): PrayerTimesCacheKey => {
+  const [year, month] = getYearAndMonth(date);
+  return { latitude, longitude, method, school, year, month };
+};
+
+export const readPrayerTimesMonth = (key: PrayerTimesCacheKey): AlAdhanPrayerTimes[] | null => {
+  try {
+    const raw = localStorage.getItem(buildCacheId(key));
+    if (!raw) return null;
+    const entry = JSON.parse(raw) as PrayerTimesCacheEntry;
+    return entry.days;
+  } catch {
+    return null;
+  }
+};
+
+export const writePrayerTimesMonth = (
+  key: PrayerTimesCacheKey,
+  days: AlAdhanPrayerTimes[]
+): void => {
+  try {
+    const entry: PrayerTimesCacheEntry = { ...key, days };
+    localStorage.setItem(buildCacheId(key), JSON.stringify(entry));
+  } catch {
+    // Ignore quota / serialization errors — cache is best-effort.
+  }
+};
+
+/**
+ * Find today's row inside a monthly Al-Adhan response.
+ * Al-Adhan dates are formatted as DD-MM-YYYY (matching `formatDate`).
+ */
+export const findTodayInMonth = (
+  days: AlAdhanPrayerTimes[],
+  date: Date
+): AlAdhanPrayerTimes | null => {
+  const target = formatDate(date);
+  return days.find(row => row.date.gregorian.date === target) ?? null;
+};

--- a/src/utils/weather-cache.ts
+++ b/src/utils/weather-cache.ts
@@ -1,0 +1,34 @@
+import type { OpenWeatherForecastResponse } from '@/types';
+
+const WEATHER_CACHE_KEY = 'weather_forecast_cache_v1';
+
+type WeatherCacheEntry = {
+  lat: number;
+  lon: number;
+  data: OpenWeatherForecastResponse;
+};
+
+export const readWeatherCache = (lat: number, lon: number): OpenWeatherForecastResponse | null => {
+  try {
+    const raw = localStorage.getItem(WEATHER_CACHE_KEY);
+    if (!raw) return null;
+    const entry = JSON.parse(raw) as WeatherCacheEntry;
+    if (entry.lat !== lat || entry.lon !== lon) return null;
+    return entry.data;
+  } catch {
+    return null;
+  }
+};
+
+export const writeWeatherCache = (
+  lat: number,
+  lon: number,
+  data: OpenWeatherForecastResponse
+): void => {
+  try {
+    const entry: WeatherCacheEntry = { lat, lon, data };
+    localStorage.setItem(WEATHER_CACHE_KEY, JSON.stringify(entry));
+  } catch {
+    // Ignore quota / serialization errors — cache is best-effort.
+  }
+};

--- a/src/utils/weather.ts
+++ b/src/utils/weather.ts
@@ -5,39 +5,6 @@ import type {
   WeatherForecast,
 } from '@/types';
 
-const WEATHER_CACHE_KEY = 'weather_forecast_cache_v1';
-
-type WeatherCacheEntry = {
-  lat: number;
-  lon: number;
-  data: OpenWeatherForecastResponse;
-};
-
-export const readWeatherCache = (lat: number, lon: number): OpenWeatherForecastResponse | null => {
-  try {
-    const raw = localStorage.getItem(WEATHER_CACHE_KEY);
-    if (!raw) return null;
-    const entry = JSON.parse(raw) as WeatherCacheEntry;
-    if (entry.lat !== lat || entry.lon !== lon) return null;
-    return entry.data;
-  } catch {
-    return null;
-  }
-};
-
-export const writeWeatherCache = (
-  lat: number,
-  lon: number,
-  data: OpenWeatherForecastResponse
-): void => {
-  try {
-    const entry: WeatherCacheEntry = { lat, lon, data };
-    localStorage.setItem(WEATHER_CACHE_KEY, JSON.stringify(entry));
-  } catch {
-    // Ignore quota / serialization errors — cache is best-effort.
-  }
-};
-
 export const parseOpenWeatherForecast = (data: OpenWeatherForecastResponse): WeatherForecast => {
   // Get current weather from the first forecast item (most recent)
   const currentItem = data.list[0];

--- a/supabase/migrations/20260508000001_enable_realtime_for_display_tables.sql
+++ b/supabase/migrations/20260508000001_enable_realtime_for_display_tables.sql
@@ -1,0 +1,32 @@
+-- Enable Supabase Realtime on every table the display module reads.
+-- Without these, the display can subscribe to channels but the database
+-- never publishes row changes, so admin edits won't push to live screens.
+--
+-- Adding to the supabase_realtime publication is the supported mechanism.
+-- The DO block makes this idempotent (Postgres has no IF NOT EXISTS for
+-- ALTER PUBLICATION ... ADD TABLE).
+DO $$
+DECLARE
+  tbl text;
+  tables text[] := ARRAY[
+    'display_screens',
+    'screen_content',
+    'settings',
+    'prayer_times',
+    'masjid_profiles',
+    'announcements',
+    'events',
+    'posts',
+    'youtube_videos',
+    'ayat_and_hadith'
+  ];
+BEGIN
+  FOREACH tbl IN ARRAY tables LOOP
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_publication_tables
+      WHERE pubname = 'supabase_realtime' AND tablename = tbl
+    ) THEN
+      EXECUTE format('ALTER PUBLICATION supabase_realtime ADD TABLE public.%I', tbl);
+    END IF;
+  END LOOP;
+END $$;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import legacy from '@vitejs/plugin-legacy';
+import { VitePWA } from 'vite-plugin-pwa';
 import path from 'path';
 
 // https://vite.dev/config/
@@ -13,6 +14,100 @@ export default defineConfig({
       modernPolyfills: true,
       renderLegacyChunks: true,
       additionalLegacyPolyfills: ['regenerator-runtime/runtime'],
+    }),
+    VitePWA({
+      registerType: 'autoUpdate',
+      injectRegister: 'auto',
+      workbox: {
+        globPatterns: ['**/*.{js,css,html,ico,png,svg,webp,woff,woff2}'],
+        navigateFallback: '/index.html',
+        // Display screens can build up a lot of large images over time
+        // (announcements, posts, ayat-hadith canvases). Bump the precache
+        // size limit so the build doesn't fail and let runtime caching pick
+        // up large media at request time.
+        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
+        runtimeCaching: [
+          {
+            // Supabase storage (announcement / event / post / ayat-hadith images)
+            urlPattern: /^https:\/\/[^/]+\.supabase\.co\/storage\/v1\/object\//,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'supabase-storage',
+              expiration: {
+                maxEntries: 200,
+                maxAgeSeconds: 60 * 60 * 24 * 30, // 30 days
+              },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+          {
+            // Al-Adhan prayer times API
+            urlPattern: /^https:\/\/api\.aladhan\.com\//,
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'aladhan-api',
+              networkTimeoutSeconds: 8,
+              expiration: {
+                maxEntries: 50,
+                maxAgeSeconds: 60 * 60 * 24 * 35, // ~ one extra month buffer
+              },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+          {
+            // OpenWeather forecast API
+            urlPattern: /^https:\/\/api\.openweathermap\.org\//,
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'openweather-api',
+              networkTimeoutSeconds: 6,
+              expiration: {
+                maxEntries: 20,
+                maxAgeSeconds: 60 * 60 * 24, // 1 day
+              },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+          {
+            // Google Fonts stylesheet
+            urlPattern: /^https:\/\/fonts\.googleapis\.com\//,
+            handler: 'StaleWhileRevalidate',
+            options: {
+              cacheName: 'google-fonts-stylesheets',
+            },
+          },
+          {
+            // Google Fonts files
+            urlPattern: /^https:\/\/fonts\.gstatic\.com\//,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'google-fonts-webfonts',
+              expiration: {
+                maxEntries: 30,
+                maxAgeSeconds: 60 * 60 * 24 * 365, // 1 year
+              },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+        ],
+      },
+      manifest: {
+        name: 'Prayer Box',
+        short_name: 'Prayer Box',
+        description: 'Mosque display screens for prayer times, announcements, and content.',
+        theme_color: '#000000',
+        background_color: '#000000',
+        display: 'standalone',
+        start_url: '/',
+        icons: [
+          {
+            src: '/vite.svg',
+            sizes: 'any',
+            type: 'image/svg+xml',
+            purpose: 'any',
+          },
+        ],
+      },
     }),
   ],
   build: {


### PR DESCRIPTION
## Summary
- **Offline survival**: display now hydrates from `localStorage` (screen content, prayer times for the full month, weather), filters YouTube slides when `navigator.onLine` is false, and uses a `vite-plugin-pwa` service worker to cache the app shell and Supabase storage images. Failed network calls keep showing cached data instead of erroring.
- **Live admin edits**: display subscribes to Supabase Realtime on `display_screens`, `screen_content`, `settings`, `prayer_times`, `masjid_profiles`, and all 5 content tables. Edits in the admin panel propagate without a reload, debounced 250ms to coalesce bursts (e.g. reordering).
- **Helpers**: `subscribeToTableChanges` in `src/lib/supabase/realtime.ts` and `useRealtimeRefresh` hook keep the subscription/debounce/cleanup logic in one place.

## Migration
`supabase/migrations/20260508000001_enable_realtime_for_display_tables.sql` adds the 10 tables to the `supabase_realtime` publication. Already applied to the linked remote project — re-running is a no-op (idempotent DO block).

## Test plan
- [ ] Load the display, then go offline (DevTools → Network → Offline) and hard-reload — text content, prayer times slide, last weather, and announcement images should all render.
- [ ] Edit an announcement in the admin panel — display picks up the change within ~250ms with no reload.
- [ ] Reorder content on a screen — display reflects the new order (one refetch, not many).
- [ ] Toggle `show_prayer_times` on a screen — slide appears/disappears live.
- [ ] Change calculation method or juristic school in settings — prayer times refetch live.
- [ ] Change masjid lat/lon — prayer times and weather both update live.
- [ ] Cross midnight while offline — prayer times advance to today's row from cached month.

## Notes
- PWA manifest reuses `/vite.svg` as the icon — fine for function, swap in real icons later.
- Workbox emits ES2017+; SW won't register on Chrome 49–54. App still works (no SW cache there). Bump the legacy floor or ignore.
- `npm install` for `vite-plugin-pwa` used `--legacy-peer-deps` to match the pre-existing `react-day-picker@8` ↔ `react@19` peer-dep conflict.