### PR TITLE
ci: bump checkout and setup-node to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout@v4` → `@v5` and `actions/setup-node@v4` → `@v5`. The v5 releases run on Node.js 24, addressing the Node 20 deprecation warning. Node.js 20 will be removed from the GitHub runner on 2026-09-16.
- The `node-version: 20` setting (which controls the Node used for `npm ci` / `lint` / `tsc` / `build`) is unchanged. That's a separate decision from the action runtime.

## Test plan
- [ ] CI runs green on this PR.
- [ ] Deprecation warning is gone from the run log.