### PR TITLE
feat(ayat-hadith): customizable reference text with toggle

### DIFF
--- a/src/components/ayat-hadith-designer/canvas.tsx
+++ b/src/components/ayat-hadith-designer/canvas.tsx
@@ -41,7 +41,8 @@ export const Canvas = forwardRef<HTMLDivElement, CanvasProps>(function Canvas(
   const arabicFont = resolveFont('arabic', style.arabic.font_id);
   const urduFont = resolveFont('urdu', style.urdu.font_id);
   const englishFont = resolveFont('english', style.english.font_id);
-  const referenceFont = resolveFont('english', style.reference.font_id);
+  const referenceEnglishFont = resolveFont('english', style.reference.font_id);
+  const referenceArabicFont = resolveFont('arabic', style.reference.arabic_font_id);
 
   const backgroundStyle: React.CSSProperties = (() => {
     if (bg.type === 'image') {
@@ -134,13 +135,18 @@ export const Canvas = forwardRef<HTMLDivElement, CanvasProps>(function Canvas(
           {showReference && cachedText.reference && (
             <div
               style={{
-                fontFamily: referenceFont.family,
                 fontSize: style.reference.size,
                 color: style.reference.color,
                 lineHeight: style.reference.line_height,
               }}
             >
-              {cachedText.reference}
+              <span dir='rtl' style={{ fontFamily: referenceArabicFont.family }}>
+                {cachedText.reference.arabic}
+              </span>
+              {' - '}
+              <span dir='ltr' style={{ fontFamily: referenceEnglishFont.family }}>
+                {cachedText.reference.english}
+              </span>
             </div>
           )}
         </div>

--- a/src/components/ayat-hadith-designer/canvas.tsx
+++ b/src/components/ayat-hadith-designer/canvas.tsx
@@ -1,40 +1,19 @@
 import { forwardRef, useEffect, useRef, useState } from 'react';
-import { CANVAS_DIMENSIONS, HADITH_BOOKS, SURAHS } from '@/constants';
-import type {
-  AyatHadithCachedText,
-  AyatHadithStyle,
-  AyatHadithType,
-  AyatSource,
-  HadithSource,
-  ScreenOrientation,
-} from '@/types';
+import { CANVAS_DIMENSIONS } from '@/constants';
+import type { AyatHadithCachedText, AyatHadithStyle, ScreenOrientation } from '@/types';
 import { hexWithOpacity, resolveBackground, resolveFont } from './helpers';
 
 interface CanvasProps {
   orientation: ScreenOrientation;
-  type: AyatHadithType;
-  source: AyatSource | HadithSource;
   style: AyatHadithStyle;
   cachedText: AyatHadithCachedText;
   showUrdu: boolean;
   showEnglish: boolean;
-}
-
-function resolveSourceLine(type: AyatHadithType, source: AyatSource | HadithSource): string | null {
-  if (type === 'ayat') {
-    const s = source as AyatSource;
-    const surah = SURAHS.find(x => x.number === s.surah);
-    if (!surah) return null;
-    return `سُورَة ${surah.name_arabic} - ${surah.name_english} (Ch. ${surah.number})`;
-  }
-  const h = source as HadithSource;
-  const book = HADITH_BOOKS.find(b => b.slug === h.book);
-  if (!book || !h.hadith_number) return null;
-  return `${book.name_arabic} - ${book.name} (#${h.hadith_number})`;
+  showReference: boolean;
 }
 
 export const Canvas = forwardRef<HTMLDivElement, CanvasProps>(function Canvas(
-  { orientation, type, source, style, cachedText, showUrdu, showEnglish },
+  { orientation, style, cachedText, showUrdu, showEnglish, showReference },
   ref
 ) {
   const [width, height] = CANVAS_DIMENSIONS[orientation];
@@ -62,7 +41,7 @@ export const Canvas = forwardRef<HTMLDivElement, CanvasProps>(function Canvas(
   const arabicFont = resolveFont('arabic', style.arabic.font_id);
   const urduFont = resolveFont('urdu', style.urdu.font_id);
   const englishFont = resolveFont('english', style.english.font_id);
-  const sourceLine = resolveSourceLine(type, source);
+  const referenceFont = resolveFont('english', style.reference.font_id);
 
   const backgroundStyle: React.CSSProperties = (() => {
     if (bg.type === 'image') {
@@ -94,43 +73,6 @@ export const Canvas = forwardRef<HTMLDivElement, CanvasProps>(function Canvas(
           ...backgroundStyle,
         }}
       >
-        <div
-          style={{
-            position: 'absolute',
-            top: '6%',
-            left: '6%',
-            right: '6%',
-            color: style.arabic.color,
-            textAlign: 'center',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            gap: '0.4em',
-          }}
-        >
-          <div
-            style={{
-              fontFamily: englishFont.family,
-              fontSize: Math.round(style.english.size * 0.85),
-              fontWeight: 600,
-              lineHeight: 1.2,
-            }}
-          >
-            I made this on <span style={{ fontWeight: 800 }}>PrayerBox</span>
-          </div>
-          {sourceLine && (
-            <div
-              style={{
-                fontFamily: englishFont.family,
-                fontSize: Math.round(style.english.size * 0.7),
-                opacity: 0.9,
-                lineHeight: 1.2,
-              }}
-            >
-              {sourceLine}
-            </div>
-          )}
-        </div>
         <div
           style={{
             position: 'absolute',
@@ -187,6 +129,18 @@ export const Canvas = forwardRef<HTMLDivElement, CanvasProps>(function Canvas(
               }}
             >
               {cachedText.english.text}
+            </div>
+          )}
+          {showReference && cachedText.reference && (
+            <div
+              style={{
+                fontFamily: referenceFont.family,
+                fontSize: style.reference.size,
+                color: style.reference.color,
+                lineHeight: style.reference.line_height,
+              }}
+            >
+              {cachedText.reference}
             </div>
           )}
         </div>

--- a/src/components/ayat-hadith-designer/content-panel.tsx
+++ b/src/components/ayat-hadith-designer/content-panel.tsx
@@ -20,6 +20,18 @@ import type { AyatHadithCachedText, AyatHadithType } from '@/types';
 import { Check, Loader2 } from 'lucide-react';
 import { cn } from '@/utils';
 
+function buildAyatReference(surahNumber: number): string | undefined {
+  const surah = SURAHS.find(s => s.number === surahNumber);
+  if (!surah) return undefined;
+  return `سُورَة ${surah.name_arabic} - ${surah.name_english} (Ch. ${surah.number})`;
+}
+
+function buildHadithReference(bookSlug: string, hadithNumber: string): string | undefined {
+  const book = HADITH_BOOKS.find(b => b.slug === bookSlug);
+  if (!book || !hadithNumber) return undefined;
+  return `${book.name_arabic} - ${book.name} (#${hadithNumber})`;
+}
+
 export interface ContentState {
   type: AyatHadithType;
   surah: number;
@@ -30,6 +42,7 @@ export interface ContentState {
   urduEdition: string;
   showEnglish: boolean;
   englishEdition: string;
+  showReference: boolean;
 }
 
 interface ContentPanelProps {
@@ -41,8 +54,8 @@ interface ContentPanelProps {
 
 function fingerprint(s: ContentState): string {
   return s.type === 'ayat'
-    ? `ayat|${s.surah}|${s.ayah}|${s.showUrdu}|${s.urduEdition}|${s.showEnglish}|${s.englishEdition}`
-    : `hadith|${s.book}|${s.hadith_number}|${s.showUrdu}|${s.showEnglish}`;
+    ? `ayat|${s.surah}|${s.ayah}|${s.showUrdu}|${s.urduEdition}|${s.showEnglish}|${s.englishEdition}|${s.showReference}`
+    : `hadith|${s.book}|${s.hadith_number}|${s.showUrdu}|${s.showEnglish}|${s.showReference}`;
 }
 
 export function ContentPanel({
@@ -96,6 +109,10 @@ export function ContentPanel({
               text: result.translations[state.englishEdition],
             };
           }
+          if (state.showReference) {
+            const reference = buildAyatReference(state.surah);
+            if (reference) next.reference = reference;
+          }
           onCachedTextChange(next);
         } else {
           const hadith = await fetchHadith(state.book, state.hadith_number, controller.signal);
@@ -105,6 +122,10 @@ export function ContentPanel({
           }
           if (state.showEnglish && hadith.english) {
             next.english = { edition: 'hadithapi-english', text: hadith.english };
+          }
+          if (state.showReference) {
+            const reference = buildHadithReference(state.book, state.hadith_number);
+            if (reference) next.reference = reference;
           }
           onCachedTextChange(next);
         }
@@ -328,6 +349,27 @@ export function ContentPanel({
             </button>
           </div>
         )}
+
+        <button
+          type='button'
+          onClick={() => onChange({ ...state, showReference: !state.showReference })}
+          className={cn(
+            'w-full inline-flex items-center justify-center gap-2 rounded-md border px-4 py-2.5 text-sm font-medium transition',
+            state.showReference
+              ? 'border-primary bg-primary/10 text-foreground'
+              : 'border-border bg-transparent text-muted-foreground hover:bg-accent hover:text-foreground'
+          )}
+        >
+          <span
+            className={cn(
+              'flex h-4 w-4 items-center justify-center rounded-sm border transition',
+              state.showReference ? 'border-primary bg-primary' : 'border-muted-foreground/40'
+            )}
+          >
+            {state.showReference && <Check className='h-3 w-3 text-primary-foreground' />}
+          </span>
+          Reference
+        </button>
       </div>
 
       {error && <p className='text-destructive text-sm'>{error}</p>}

--- a/src/components/ayat-hadith-designer/content-panel.tsx
+++ b/src/components/ayat-hadith-designer/content-panel.tsx
@@ -382,7 +382,7 @@ export function ContentPanel({
         disabled={fetching}
       >
         {fetching && <Loader2 className='mr-2 h-3 w-3 animate-spin' />}
-        Re-fetch from API
+        Refresh
       </Button>
     </div>
   );

--- a/src/components/ayat-hadith-designer/content-panel.tsx
+++ b/src/components/ayat-hadith-designer/content-panel.tsx
@@ -20,16 +20,25 @@ import type { AyatHadithCachedText, AyatHadithType } from '@/types';
 import { Check, Loader2 } from 'lucide-react';
 import { cn } from '@/utils';
 
-function buildAyatReference(surahNumber: number): string | undefined {
+function buildAyatReference(surahNumber: number): { arabic: string; english: string } | undefined {
   const surah = SURAHS.find(s => s.number === surahNumber);
   if (!surah) return undefined;
-  return `سُورَة ${surah.name_arabic} - ${surah.name_english} (Ch. ${surah.number})`;
+  return {
+    arabic: `سُورَة ${surah.name_arabic}`,
+    english: `${surah.name_english} (Ch. ${surah.number})`,
+  };
 }
 
-function buildHadithReference(bookSlug: string, hadithNumber: string): string | undefined {
+function buildHadithReference(
+  bookSlug: string,
+  hadithNumber: string
+): { arabic: string; english: string } | undefined {
   const book = HADITH_BOOKS.find(b => b.slug === bookSlug);
   if (!book || !hadithNumber) return undefined;
-  return `${book.name_arabic} - ${book.name} (#${hadithNumber})`;
+  return {
+    arabic: book.name_arabic,
+    english: `${book.name} (#${hadithNumber})`,
+  };
 }
 
 export interface ContentState {

--- a/src/components/ayat-hadith-designer/design-panel.tsx
+++ b/src/components/ayat-hadith-designer/design-panel.tsx
@@ -17,9 +17,16 @@ interface DesignPanelProps {
   onChange: (next: AyatHadithStyle) => void;
   showUrdu: boolean;
   showEnglish: boolean;
+  showReference: boolean;
 }
 
-export function DesignPanel({ style, onChange, showUrdu, showEnglish }: DesignPanelProps) {
+export function DesignPanel({
+  style,
+  onChange,
+  showUrdu,
+  showEnglish,
+  showReference,
+}: DesignPanelProps) {
   const update = (patch: Partial<AyatHadithStyle>) => onChange({ ...style, ...patch });
 
   const images = BACKGROUNDS.filter(b => b.type === 'image');
@@ -117,6 +124,15 @@ export function DesignPanel({ style, onChange, showUrdu, showEnglish }: DesignPa
           category='english'
           style={style.english}
           onChange={next => update({ english: next })}
+        />
+      )}
+
+      {showReference && (
+        <TextStyleControls
+          label='Reference'
+          category='english'
+          style={style.reference}
+          onChange={next => update({ reference: next })}
         />
       )}
     </div>

--- a/src/components/ayat-hadith-designer/design-panel.tsx
+++ b/src/components/ayat-hadith-designer/design-panel.tsx
@@ -9,7 +9,7 @@ import {
   Slider,
 } from '@/components/ui';
 import { BACKGROUNDS, FONTS } from '@/constants';
-import type { AyatHadithStyle } from '@/types';
+import type { AyatHadithReferenceStyle, AyatHadithStyle } from '@/types';
 import { cn } from '@/utils';
 
 interface DesignPanelProps {
@@ -128,14 +128,93 @@ export function DesignPanel({
       )}
 
       {showReference && (
-        <TextStyleControls
-          label='Reference'
-          category='english'
+        <ReferenceStyleControls
           style={style.reference}
           onChange={next => update({ reference: next })}
         />
       )}
     </div>
+  );
+}
+
+interface ReferenceStyleControlsProps {
+  style: AyatHadithReferenceStyle;
+  onChange: (next: AyatHadithReferenceStyle) => void;
+}
+
+function ReferenceStyleControls({ style, onChange }: ReferenceStyleControlsProps) {
+  return (
+    <section className='space-y-3 border-t pt-4'>
+      <Label className='text-sm font-semibold'>Reference</Label>
+      <div className='grid grid-cols-2 gap-3'>
+        <div className='space-y-2'>
+          <Label className='text-xs text-muted-foreground'>Arabic font</Label>
+          <Select
+            value={style.arabic_font_id}
+            onValueChange={v => onChange({ ...style, arabic_font_id: v })}
+          >
+            <SelectTrigger className='w-full'>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {FONTS.arabic.map(f => (
+                <SelectItem key={f.id} value={f.id}>
+                  {f.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className='space-y-2'>
+          <Label className='text-xs text-muted-foreground'>English font</Label>
+          <Select value={style.font_id} onValueChange={v => onChange({ ...style, font_id: v })}>
+            <SelectTrigger className='w-full'>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {FONTS.english.map(f => (
+                <SelectItem key={f.id} value={f.id}>
+                  {f.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className='flex items-center gap-3'>
+        <div className='flex-1 space-y-2'>
+          <Label className='text-xs text-muted-foreground'>Size: {style.size}px</Label>
+          <Slider
+            min={16}
+            max={200}
+            step={2}
+            value={[style.size]}
+            onValueChange={v => onChange({ ...style, size: v[0] })}
+          />
+        </div>
+        <div className='space-y-2'>
+          <Label className='text-xs text-muted-foreground'>Color</Label>
+          <Input
+            type='color'
+            value={style.color}
+            onChange={e => onChange({ ...style, color: e.target.value })}
+            className='h-9 w-14 p-1'
+          />
+        </div>
+      </div>
+      <div className='space-y-2'>
+        <Label className='text-xs text-muted-foreground'>
+          Line spacing: {style.line_height.toFixed(1)}
+        </Label>
+        <Slider
+          min={1}
+          max={3}
+          step={0.1}
+          value={[style.line_height]}
+          onValueChange={v => onChange({ ...style, line_height: v[0] })}
+        />
+      </div>
+    </section>
   );
 }
 
@@ -162,7 +241,7 @@ function TextStyleControls({ label, category, style, onChange }: TextStyleContro
       <div className='space-y-2'>
         <Label className='text-xs text-muted-foreground'>Font</Label>
         <Select value={style.font_id} onValueChange={v => onChange({ ...style, font_id: v })}>
-          <SelectTrigger>
+          <SelectTrigger className='w-full'>
             <SelectValue />
           </SelectTrigger>
           <SelectContent>

--- a/src/constants/slide-design.ts
+++ b/src/constants/slide-design.ts
@@ -103,4 +103,5 @@ export const DEFAULT_STYLE = {
   arabic: { font_id: 'amiri', size: 72, color: '#ffffff', line_height: 1.6 },
   urdu: { font_id: 'noto-nastaliq', size: 40, color: '#ffffff', line_height: 1.8 },
   english: { font_id: 'inter', size: 36, color: '#ffffff', line_height: 1.5 },
+  reference: { font_id: 'inter', size: 28, color: '#ffffff', line_height: 1.3 },
 };

--- a/src/constants/slide-design.ts
+++ b/src/constants/slide-design.ts
@@ -103,5 +103,11 @@ export const DEFAULT_STYLE = {
   arabic: { font_id: 'amiri', size: 72, color: '#ffffff', line_height: 1.6 },
   urdu: { font_id: 'noto-nastaliq', size: 40, color: '#ffffff', line_height: 1.8 },
   english: { font_id: 'inter', size: 36, color: '#ffffff', line_height: 1.5 },
-  reference: { font_id: 'inter', size: 28, color: '#ffffff', line_height: 1.3 },
+  reference: {
+    font_id: 'inter',
+    arabic_font_id: 'amiri',
+    size: 28,
+    color: '#ffffff',
+    line_height: 1.3,
+  },
 };

--- a/src/lib/zod.ts
+++ b/src/lib/zod.ts
@@ -210,6 +210,7 @@ const ayatHadithStyleSchema = z.object({
   arabic: textStyleSchema,
   urdu: textStyleSchema,
   english: textStyleSchema,
+  reference: textStyleSchema,
 });
 
 const ayatSourceSchema = z.object({
@@ -226,6 +227,7 @@ const cachedTextSchema = z.object({
   arabic: z.string(),
   urdu: z.object({ edition: z.string(), text: z.string() }).optional(),
   english: z.object({ edition: z.string(), text: z.string() }).optional(),
+  reference: z.string().optional(),
 });
 
 export const ayatAndHadithSchema = z.object({

--- a/src/lib/zod.ts
+++ b/src/lib/zod.ts
@@ -203,6 +203,14 @@ const textStyleSchema = z.object({
   line_height: z.number().min(0.8).max(4),
 });
 
+const referenceStyleSchema = z.object({
+  font_id: z.string(),
+  arabic_font_id: z.string(),
+  size: z.number().min(8).max(300),
+  color: z.string(),
+  line_height: z.number().min(0.8).max(4),
+});
+
 const ayatHadithStyleSchema = z.object({
   background_id: z.string(),
   overlay_color: z.string(),
@@ -210,7 +218,7 @@ const ayatHadithStyleSchema = z.object({
   arabic: textStyleSchema,
   urdu: textStyleSchema,
   english: textStyleSchema,
-  reference: textStyleSchema,
+  reference: referenceStyleSchema,
 });
 
 const ayatSourceSchema = z.object({
@@ -227,7 +235,7 @@ const cachedTextSchema = z.object({
   arabic: z.string(),
   urdu: z.object({ edition: z.string(), text: z.string() }).optional(),
   english: z.object({ edition: z.string(), text: z.string() }).optional(),
-  reference: z.string().optional(),
+  reference: z.object({ arabic: z.string(), english: z.string() }).optional(),
 });
 
 export const ayatAndHadithSchema = z.object({

--- a/src/pages/app/ayat-hadith-designer.tsx
+++ b/src/pages/app/ayat-hadith-designer.tsx
@@ -33,6 +33,7 @@ function makeInitialContentState(initial?: AyatAndHadith | null): ContentState {
       urduEdition: QURAN_TRANSLATIONS.urdu[0].id,
       showEnglish: true,
       englishEdition: QURAN_TRANSLATIONS.english[0].id,
+      showReference: true,
     };
   }
 
@@ -48,6 +49,7 @@ function makeInitialContentState(initial?: AyatAndHadith | null): ContentState {
       urduEdition: initial.cached_text.urdu?.edition ?? QURAN_TRANSLATIONS.urdu[0].id,
       showEnglish: !!initial.cached_text.english,
       englishEdition: initial.cached_text.english?.edition ?? QURAN_TRANSLATIONS.english[0].id,
+      showReference: !!initial.cached_text.reference,
     };
   }
 
@@ -62,6 +64,7 @@ function makeInitialContentState(initial?: AyatAndHadith | null): ContentState {
     urduEdition: 'hadithapi-urdu',
     showEnglish: !!initial.cached_text.english,
     englishEdition: 'hadithapi-english',
+    showReference: !!initial.cached_text.reference,
   };
 }
 
@@ -119,7 +122,11 @@ export default function AyatHadithDesigner() {
         setOrientation(slide.orientation);
         setContent(makeInitialContentState(slide));
         setCachedText(slide.cached_text);
-        setStyle(slide.style);
+        setStyle({
+          ...DEFAULT_STYLE,
+          ...slide.style,
+          reference: slide.style.reference ?? DEFAULT_STYLE.reference,
+        });
       })
       .catch(err => {
         console.error(err);
@@ -226,12 +233,11 @@ export default function AyatHadithDesigner() {
           <Canvas
             ref={canvasRef}
             orientation={orientation}
-            type={content.type}
-            source={buildSource()}
             style={style}
             cachedText={cachedText}
             showUrdu={content.showUrdu}
             showEnglish={content.showEnglish}
+            showReference={content.showReference}
           />
         </div>
         <div className='overflow-y-auto pr-2'>
@@ -254,6 +260,7 @@ export default function AyatHadithDesigner() {
                 onChange={setStyle}
                 showUrdu={content.showUrdu}
                 showEnglish={content.showEnglish}
+                showReference={content.showReference}
               />
             </TabsContent>
           </Tabs>

--- a/src/pages/app/ayat-hadith-designer.tsx
+++ b/src/pages/app/ayat-hadith-designer.tsx
@@ -125,7 +125,7 @@ export default function AyatHadithDesigner() {
         setStyle({
           ...DEFAULT_STYLE,
           ...slide.style,
-          reference: slide.style.reference ?? DEFAULT_STYLE.reference,
+          reference: { ...DEFAULT_STYLE.reference, ...(slide.style.reference ?? {}) },
         });
       })
       .catch(err => {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -80,6 +80,7 @@ export interface AyatHadithCachedText {
   arabic: string;
   urdu?: { edition: string; text: string };
   english?: { edition: string; text: string };
+  reference?: string;
 }
 
 export interface AyatHadithTextStyle {
@@ -96,6 +97,7 @@ export interface AyatHadithStyle {
   arabic: AyatHadithTextStyle;
   urdu: AyatHadithTextStyle;
   english: AyatHadithTextStyle;
+  reference: AyatHadithTextStyle;
 }
 
 export interface AyatAndHadith extends Base {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -80,7 +80,7 @@ export interface AyatHadithCachedText {
   arabic: string;
   urdu?: { edition: string; text: string };
   english?: { edition: string; text: string };
-  reference?: string;
+  reference?: { arabic: string; english: string };
 }
 
 export interface AyatHadithTextStyle {
@@ -90,6 +90,10 @@ export interface AyatHadithTextStyle {
   line_height: number;
 }
 
+export interface AyatHadithReferenceStyle extends AyatHadithTextStyle {
+  arabic_font_id: string;
+}
+
 export interface AyatHadithStyle {
   background_id: string;
   overlay_color: string;
@@ -97,7 +101,7 @@ export interface AyatHadithStyle {
   arabic: AyatHadithTextStyle;
   urdu: AyatHadithTextStyle;
   english: AyatHadithTextStyle;
-  reference: AyatHadithTextStyle;
+  reference: AyatHadithReferenceStyle;
 }
 
 export interface AyatAndHadith extends Base {


### PR DESCRIPTION
## Summary
- Remove the hardcoded "I made this on PrayerBox" header from Ayat/Hadith slides.
- Move the source/reference line into the overlay at the bottom, alongside the Arabic/Urdu/English blocks.
- Reference is now a first-class text block: cached on fetch (`cached_text.reference`), styled via `style.reference`, and toggleable from the Content panel.
- Reference text mixes Arabic and English, so it's split into `{ arabic, english }` parts and each renders with its own font/direction. The Design panel gains a side-by-side Arabic font + English font picker (shared size/color/line spacing).
- Hadith translation toggles now match the Ayat style (checkbox-button toggle + edition select on the same row for ayat, plain toggle for hadith since editions are fixed).
- Existing text-style font selects are full-width for visual consistency.
- "Re-fetch from API" button renamed to "Refresh".
- Legacy rows without `style.reference` or `style.reference.arabic_font_id` get defaults applied via a deep merge at load — no migration needed (both columns are JSONB).

## Commits
- `feat(ayat-hadith): customizable reference text with toggle`
- `chore(ayat-hadith): rename "Re-fetch from API" button to "Refresh"`
- `feat(ayat-hadith): split reference into Arabic + English parts with separate fonts`

## Test plan
- [ ] Open the designer in **create** mode → reference toggle defaults on, source line renders at the bottom of the overlay with Arabic + English parts.
- [ ] Open the designer in **edit** mode on a pre-existing slide → loads cleanly with default reference style applied; saving re-persists with `style.reference` (incl. `arabic_font_id`) and `cached_text.reference: { arabic, english }`.
- [ ] Toggle Reference off → reference disappears from the canvas; "Reference" section in Design panel hides.
- [ ] Toggle Urdu / English off → corresponding section in Design panel hides.
- [ ] Change reference Arabic font, English font, size, color, line spacing → updates reflect in the canvas and persist after save.
- [ ] Switch between ayat and hadith → reference rebuilds correctly for each source type.
- [ ] "Refresh" button retriggers the API fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)