### PR TITLE
feat(screens): goto action, delete on detail, theme reposition, shadcn select

### DIFF
--- a/src/components/common/action-buttons.tsx
+++ b/src/components/common/action-buttons.tsx
@@ -1,24 +1,31 @@
 import { Button } from '@/components/ui';
-import { Edit, Trash2, Monitor } from 'lucide-react';
+import { ArrowRight, Edit, Trash2, Monitor } from 'lucide-react';
 
 type ActionButtonsProps = {
-  onEdit: () => void;
+  onEdit?: () => void;
   onDelete: () => void;
   onScreens?: () => void;
+  onGoto?: () => void;
   centered?: boolean;
 };
 
 /**
- * Renders action buttons for editing, deleting, and optionally assigning to screens
+ * Renders action buttons for opening, editing, deleting, and optionally assigning to screens
  */
 export function ActionButtons({
   onEdit,
   onDelete,
   onScreens,
+  onGoto,
   centered = true,
 }: ActionButtonsProps) {
   return (
     <div className={`flex ${centered ? 'justify-center' : ''} space-x-1`}>
+      {onGoto && (
+        <Button variant='ghost' size='sm' onClick={onGoto} title='Open' className='hover:bg-muted'>
+          <ArrowRight className='h-4 w-4' />
+        </Button>
+      )}
       {onScreens && (
         <Button
           variant='ghost'
@@ -30,9 +37,11 @@ export function ActionButtons({
           <Monitor className='h-4 w-4' />
         </Button>
       )}
-      <Button variant='ghost' size='sm' onClick={onEdit} title='Edit' className='hover:bg-muted'>
-        <Edit className='h-4 w-4' />
-      </Button>
+      {onEdit && (
+        <Button variant='ghost' size='sm' onClick={onEdit} title='Edit' className='hover:bg-muted'>
+          <Edit className='h-4 w-4' />
+        </Button>
+      )}
       <Button
         variant='ghost'
         size='sm'

--- a/src/components/modals/screen-modal.tsx
+++ b/src/components/modals/screen-modal.tsx
@@ -10,6 +10,11 @@ import {
   DialogContent,
   DialogFooter,
   DialogClose,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from '@/components/ui';
 import { screenSchema, type ScreenData } from '@/lib/zod';
 import { createScreen, updateScreen } from '@/lib/supabase';
@@ -58,6 +63,7 @@ export function ScreenModal({ isOpen, onClose, onSuccess, initialData }: ScreenM
 
   const showPrayerTimes = watch('show_prayer_times');
   const showWeather = watch('show_weather');
+  const orientation = watch('orientation');
 
   useEffect(() => {
     if (isOpen) {
@@ -169,15 +175,19 @@ export function ScreenModal({ isOpen, onClose, onSuccess, initialData }: ScreenM
 
           <div className='space-y-2'>
             <Label htmlFor='orientation'>Orientation</Label>
-            <select
-              id='orientation'
-              className='flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
-              {...register('orientation')}
+            <Select
+              value={orientation}
+              onValueChange={v => setValue('orientation', v as ScreenData['orientation'])}
             >
-              <option value='landscape'>Landscape</option>
-              <option value='portrait'>Portrait</option>
-              <option value='mobile'>Mobile</option>
-            </select>
+              <SelectTrigger id='orientation' className='w-full'>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value='landscape'>Landscape</SelectItem>
+                <SelectItem value='portrait'>Portrait</SelectItem>
+                <SelectItem value='mobile'>Mobile</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
 
           <div className='space-y-3'>

--- a/src/pages/app/screen-detail.tsx
+++ b/src/pages/app/screen-detail.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react';
-import { useParams, Link } from 'react-router';
+import { useParams, Link, useNavigate } from 'react-router';
 import {
   getScreenById,
   getScreenContentWithDetails,
   updateScreenContentOrder,
   toggleScreenContentVisibility,
+  deleteScreen,
   type ScreenContentWithDetails,
 } from '@/lib/supabase';
 import type { DisplayScreen } from '@/types';
@@ -18,8 +19,8 @@ import {
   type Column,
 } from '@/components/common';
 import { ThemeSection } from '@/components/settings';
-import { ScreenModal } from '@/components/modals';
-import { ArrowLeft, Monitor, Copy, Check, Pencil } from 'lucide-react';
+import { ScreenModal, DeleteConfirmationModal } from '@/components/modals';
+import { ArrowLeft, Monitor, Copy, Check, Pencil, Trash2 } from 'lucide-react';
 import { AppRoutes } from '@/constants';
 import { useTrigger } from '@/hooks';
 import { toast } from 'sonner';
@@ -34,6 +35,7 @@ const CONTENT_TYPE_CONFIG: Record<string, { label: string; color: string }> = {
 
 export default function ScreenDetail() {
   const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
   const [screen, setScreen] = useState<DisplayScreen | null>(null);
   const [content, setContent] = useState<ScreenContentWithDetails[]>([]);
   const [loading, setLoading] = useState(true);
@@ -41,6 +43,8 @@ export default function ScreenDetail() {
   const [isUpdatingOrder, setIsUpdatingOrder] = useState(false);
   const [copiedCode, setCopiedCode] = useState(false);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const [trigger, forceUpdate] = useTrigger();
 
@@ -101,6 +105,24 @@ export default function ScreenDetail() {
       setContent(prev => prev.map(c => (c.id === item.id ? { ...c, visible: item.visible } : c)));
       console.error('Error toggling visibility:', err);
       toast.error('Failed to update visibility');
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!screen) return;
+
+    try {
+      setIsDeleting(true);
+      await deleteScreen(screen.id);
+      toast.success('Screen deleted successfully');
+      navigate(AppRoutes.Screens);
+    } catch (err) {
+      console.error('Error deleting screen:', err);
+      setError('Failed to delete screen. Please try again.');
+      toast.error('Failed to delete screen, please try again.');
+      setIsDeleteDialogOpen(false);
+    } finally {
+      setIsDeleting(false);
     }
   };
 
@@ -197,16 +219,25 @@ export default function ScreenDetail() {
 
       <ErrorAlert message={error} onClose={() => setError(null)} />
 
-      <ThemeSection screen={screen} onScreenChange={setScreen} />
-
       <Card>
         <CardHeader>
           <div className='flex justify-between items-center'>
             <CardTitle className='text-base'>Screen Info</CardTitle>
-            <Button variant='outline' size='sm' onClick={() => setIsEditModalOpen(true)}>
-              <Pencil className='h-4 w-4 mr-2' />
-              Edit
-            </Button>
+            <div className='flex items-center gap-2'>
+              <Button variant='outline' size='sm' onClick={() => setIsEditModalOpen(true)}>
+                <Pencil className='h-4 w-4 mr-2' />
+                Edit
+              </Button>
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={() => setIsDeleteDialogOpen(true)}
+                className='text-destructive hover:bg-destructive/10 hover:text-destructive'
+              >
+                <Trash2 className='h-4 w-4 mr-2' />
+                Delete
+              </Button>
+            </div>
           </div>
         </CardHeader>
         <CardContent>
@@ -248,6 +279,8 @@ export default function ScreenDetail() {
         </CardContent>
       </Card>
 
+      {screen.show_prayer_times && <ThemeSection screen={screen} onScreenChange={setScreen} />}
+
       {content.length === 0 ? (
         <EmptyState
           icon={<Monitor className='h-6 w-6 text-muted-foreground' />}
@@ -271,6 +304,16 @@ export default function ScreenDetail() {
         onClose={() => setIsEditModalOpen(false)}
         onSuccess={forceUpdate}
         initialData={screen}
+      />
+
+      <DeleteConfirmationModal
+        isOpen={isDeleteDialogOpen}
+        onClose={() => setIsDeleteDialogOpen(false)}
+        onConfirm={handleDeleteConfirm}
+        isDeleting={isDeleting}
+        itemType='screen'
+        itemTitle={screen.name}
+        itemSubtitle={screen.code}
       />
     </div>
   );

--- a/src/pages/app/screens.tsx
+++ b/src/pages/app/screens.tsx
@@ -23,7 +23,6 @@ export default function Screens() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedItem, setSelectedItem] = useState<DisplayScreen | undefined>(undefined);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [itemToDelete, setItemToDelete] = useState<DisplayScreen | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -51,18 +50,11 @@ export default function Screens() {
   }, [trigger]);
 
   const handleAddNew = () => {
-    setSelectedItem(undefined);
-    setIsModalOpen(true);
-  };
-
-  const handleEdit = (item: DisplayScreen) => {
-    setSelectedItem(item);
     setIsModalOpen(true);
   };
 
   const handleModalClose = () => {
     setIsModalOpen(false);
-    setSelectedItem(undefined);
   };
 
   const handleDeleteClick = (item: DisplayScreen) => {
@@ -193,19 +185,14 @@ export default function Screens() {
           onRowClick={item => navigate(`/admin/screens/${item.id}`)}
           renderActions={item => (
             <ActionButtons
-              onEdit={() => handleEdit(item)}
+              onGoto={() => navigate(`/admin/screens/${item.id}`)}
               onDelete={() => handleDeleteClick(item)}
             />
           )}
         />
       )}
 
-      <ScreenModal
-        isOpen={isModalOpen}
-        onClose={handleModalClose}
-        onSuccess={forceUpdate}
-        initialData={selectedItem}
-      />
+      <ScreenModal isOpen={isModalOpen} onClose={handleModalClose} onSuccess={forceUpdate} />
 
       <DeleteConfirmationModal
         isOpen={isDeleteDialogOpen}


### PR DESCRIPTION
## Summary
- Screens list: replaced the edit pencil with a goto (arrow) action that opens the screen detail page; delete remains.
- Screen detail: added a Delete button (with confirmation modal) next to Edit in the Screen Info card; on success it navigates back to the list.
- Screen detail: moved the Prayer Timings Display Theme above the assigned-content table and gated it on `show_prayer_times` so it only renders when prayer times are enabled.
- `ActionButtons`: gained an optional `onGoto` prop and made `onEdit` optional so the same component can power list rows that route to a detail page.
- `ScreenModal`: replaced the native `<select>` on Orientation with the project's shadcn `Select`, matching the dropdowns used elsewhere (e.g. Ayat & Hadith Translations).

## Test plan
- [ ] On `/admin/screens`, the row action is now an arrow icon — clicking it opens the detail page; clicking the row itself still navigates.
- [ ] On `/admin/screens`, the delete (trash) action still opens the confirmation modal and removes the screen.
- [ ] On `/admin/screens/:id`, the Screen Info card shows both Edit and Delete; deleting redirects to `/admin/screens` and toasts success.
- [ ] Toggle Prayer Times off via the Edit modal → the theme selector disappears; toggle on → it re-appears above the content table.
- [ ] Open the screen create/edit modal: the Orientation dropdown matches the styling of the Translations dropdowns and persists the selected value on submit.