### PR TITLE
feat(theme): animate theme switch with circular reveal

### DIFF
--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -22,9 +22,15 @@ export function ThemeToggle() {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align='end'>
-        <DropdownMenuItem onClick={() => setTheme('light')}>Light</DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme('dark')}>Dark</DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme('system')}>System</DropdownMenuItem>
+        <DropdownMenuItem onClick={e => setTheme('light', { x: e.clientX, y: e.clientY })}>
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={e => setTheme('dark', { x: e.clientX, y: e.clientY })}>
+          Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={e => setTheme('system', { x: e.clientX, y: e.clientY })}>
+          System
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -165,22 +165,22 @@
   * {
     @apply border-border outline-ring/50;
   }
-  
+
   :root {
-    transition: 
+    transition:
       color 0.3s ease,
       background-color 0.3s ease,
       border-color 0.3s ease;
   }
-  
+
   * {
-    transition: 
+    transition:
       color 0.2s ease,
       background-color 0.2s ease,
       border-color 0.2s ease,
       box-shadow 0.2s ease;
   }
-  
+
   body {
     @apply bg-background text-foreground font-sans;
     font-family: var(--font-family);
@@ -192,6 +192,38 @@
   input[type='button'],
   input[type='reset'] {
     @apply cursor-pointer;
+  }
+}
+
+/* Theme switch circular reveal via View Transitions API */
+@keyframes theme-reveal {
+  from {
+    clip-path: circle(0 at var(--theme-x, 50%) var(--theme-y, 50%));
+  }
+  to {
+    clip-path: circle(var(--theme-radius, 150vmax) at var(--theme-x, 50%) var(--theme-y, 50%));
+  }
+}
+
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+::view-transition-old(root) {
+  z-index: 0;
+}
+
+::view-transition-new(root) {
+  z-index: 1;
+  animation: theme-reveal 500ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation: none;
   }
 }
 

--- a/src/providers/theme-provider.tsx
+++ b/src/providers/theme-provider.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 
 type Theme = 'dark' | 'light' | 'system';
+type ThemeOrigin = { x: number; y: number };
 
 type ThemeProviderProps = {
   children: React.ReactNode;
@@ -10,7 +11,7 @@ type ThemeProviderProps = {
 
 type ThemeProviderState = {
   theme: Theme;
-  setTheme: (theme: Theme) => void;
+  setTheme: (theme: Theme, origin?: ThemeOrigin) => void;
 };
 
 const initialState: ThemeProviderState = {
@@ -20,57 +21,74 @@ const initialState: ThemeProviderState = {
 
 const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
 
+const resolveTheme = (theme: Theme): 'light' | 'dark' => {
+  if (theme === 'system') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  return theme;
+};
+
+const applyThemeClass = (theme: Theme) => {
+  const root = document.documentElement;
+  root.classList.remove('light', 'dark');
+  root.classList.add(resolveTheme(theme));
+};
+
 export function ThemeProvider({
   children,
   defaultTheme = 'system',
   storageKey = 'prayerbox-ui-theme',
   ...props
 }: ThemeProviderProps) {
-  const [theme, setTheme] = useState<Theme>(
+  const [theme, setThemeState] = useState<Theme>(
     () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
   );
 
   useEffect(() => {
-    const root = window.document.documentElement;
-
-    root.classList.remove('light', 'dark');
-
-    if (theme === 'system') {
-      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light';
-
-      root.classList.add(systemTheme);
-      return;
-    }
-
-    root.classList.add(theme);
+    applyThemeClass(theme);
   }, [theme]);
 
   useEffect(() => {
     if (theme !== 'system') return;
 
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-    const handleChange = (e: MediaQueryListEvent) => {
-      const root = window.document.documentElement;
-      root.classList.remove('light', 'dark');
-      root.classList.add(e.matches ? 'dark' : 'light');
-    };
+    const handleChange = () => applyThemeClass('system');
 
     mediaQuery.addEventListener('change', handleChange);
     return () => mediaQuery.removeEventListener('change', handleChange);
   }, [theme]);
 
-  const value = {
-    theme,
-    setTheme: (newTheme: Theme) => {
-      localStorage.setItem(storageKey, newTheme);
-      setTheme(newTheme);
-    },
+  const setTheme = (newTheme: Theme, origin?: ThemeOrigin) => {
+    localStorage.setItem(storageKey, newTheme);
+
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const supportsViewTransitions = 'startViewTransition' in document;
+
+    if (!supportsViewTransitions || reducedMotion) {
+      applyThemeClass(newTheme);
+      setThemeState(newTheme);
+      return;
+    }
+
+    const x = origin?.x ?? window.innerWidth / 2;
+    const y = origin?.y ?? window.innerHeight / 2;
+    const radius = Math.hypot(
+      Math.max(x, window.innerWidth - x),
+      Math.max(y, window.innerHeight - y)
+    );
+    const root = document.documentElement;
+    root.style.setProperty('--theme-x', `${x}px`);
+    root.style.setProperty('--theme-y', `${y}px`);
+    root.style.setProperty('--theme-radius', `${radius}px`);
+
+    document.startViewTransition(() => {
+      applyThemeClass(newTheme);
+      setThemeState(newTheme);
+    });
   };
 
   return (
-    <ThemeProviderContext.Provider {...props} value={value}>
+    <ThemeProviderContext.Provider {...props} value={{ theme, setTheme }}>
       {children}
     </ThemeProviderContext.Provider>
   );


### PR DESCRIPTION
## Summary
- Theme changes are now wrapped in `document.startViewTransition`, with the new theme revealed as a circle expanding from the click point on the toggle item.
- Origin coordinates flow from `ThemeToggle` (`e.clientX` / `e.clientY` per `DropdownMenuItem`) into `setTheme`, which sets `--theme-x`, `--theme-y`, and `--theme-radius` CSS vars before starting the transition.
- A `theme-reveal` keyframe drives `clip-path: circle(0 ...) → circle(radius ...)` on `::view-transition-new(root)` over 500ms.
- Falls back to an instant switch when the View Transitions API is unsupported or `prefers-reduced-motion: reduce` is set.

## Test plan
- [ ] In a Chromium-based browser, open the admin area, click the theme toggle → choose Light/Dark → the new theme should sweep across the screen as a circle expanding from the menu item.
- [ ] Switch repeatedly from different toggle positions; the reveal origin should track the click location.
- [ ] Enable OS-level "Reduce motion" → theme should still switch but without the circular animation.
- [ ] Open in a browser without View Transitions (older Firefox) → theme should switch instantly without errors.
- [ ] Choose "System" while OS theme matches/doesn't match — class on `<html>` updates correctly and subsequent OS theme changes still propagate while in System mode.