### PR TITLE
feat(pwa): scope service worker to display screens only

### DIFF
--- a/src/lib/pwa.ts
+++ b/src/lib/pwa.ts
@@ -1,7 +1,23 @@
 import { registerSW } from 'virtual:pwa-register';
+import { AppRoutes, AuthRoutes } from '@/constants/routes';
 import { Sentry } from './sentry';
 
+const DISPLAY_PATHS = new Set<string>([
+  AppRoutes.Display,
+  AppRoutes.DisplayLogout,
+  AuthRoutes.LoginWithCode,
+]);
+
+function isDisplayPath(pathname: string): boolean {
+  return DISPLAY_PATHS.has(pathname);
+}
+
 export function registerServiceWorker(): void {
+  if (!isDisplayPath(window.location.pathname)) {
+    void unregisterServiceWorker();
+    return;
+  }
+
   registerSW({
     immediate: true,
     onRegisterError(error) {
@@ -12,4 +28,23 @@ export function registerServiceWorker(): void {
       });
     },
   });
+}
+
+async function unregisterServiceWorker(): Promise<void> {
+  try {
+    if ('serviceWorker' in navigator) {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(registrations.map(r => r.unregister()));
+    }
+    if ('caches' in window) {
+      const keys = await caches.keys();
+      await Promise.all(keys.map(k => caches.delete(k)));
+    }
+  } catch (error) {
+    Sentry.withScope(scope => {
+      scope.setTag('source', 'pwa');
+      scope.setTag('operation', 'unregister_service_worker');
+      Sentry.captureException(error);
+    });
+  }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,6 +32,12 @@ export default defineConfig(({ mode }) => {
         workbox: {
           globPatterns: ['**/*.{js,css,html,ico,png,svg,webp,woff,woff2}'],
           navigateFallback: '/index.html',
+          navigateFallbackDenylist: [
+            /^\/admin(\/|$)/,
+            /^\/login(\/|$)/,
+            /^\/register(\/|$)/,
+            /^\/forgot-password(\/|$)/,
+          ],
           // Display screens can build up a lot of large images over time
           // (announcements, posts, ayat-hadith canvases). Bump the precache
           // size limit so the build doesn't fail and let runtime caching pick


### PR DESCRIPTION
## Summary
- Register the service worker only on display paths (`/`, `/logout`, `/login-with-code`); on every other route, unregister existing SWs and clear caches so admin users (including anyone who installed the PWA before this change) get a fresh experience.
- Add `navigateFallbackDenylist` for `/admin`, `/login`, `/register`, `/forgot-password` as defense-in-depth — a stale SW can never serve the cached `index.html` shell for those routes.
- No manifest changes: browsers won't surface an install prompt without an active SW, so admin pages effectively become non-installable as a side effect of the SW gate.

## Test plan
- [ ] `npm run build && npm run preview`, visit `/` — SW registers (DevTools → Application → Service Workers).
- [ ] Same build, visit `/admin` — no SW registered.
- [ ] Install the PWA from `/`, then navigate to `/admin` in the same browser — existing SW unregisters and caches clear.
- [ ] Install prompt only appears on display routes.