### PR TITLE
feat(ayat-hadith-designer): custom backgrounds (storage images, colors, gradients)

### DIFF
--- a/src/components/ayat-hadith-designer/canvas.tsx
+++ b/src/components/ayat-hadith-designer/canvas.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, useEffect, useRef, useState } from 'react';
 import { CANVAS_DIMENSIONS } from '@/constants';
 import type { AyatHadithCachedText, AyatHadithStyle, ScreenOrientation } from '@/types';
-import { hexWithOpacity, resolveBackground, resolveFont } from './helpers';
+import { backgroundCss, hexWithOpacity, resolveFont } from './helpers';
 
 interface CanvasProps {
   orientation: ScreenOrientation;
@@ -37,24 +37,13 @@ export const Canvas = forwardRef<HTMLDivElement, CanvasProps>(function Canvas(
     return () => ro.disconnect();
   }, [width, height]);
 
-  const bg = resolveBackground(style.background_id);
   const arabicFont = resolveFont('arabic', style.arabic.font_id);
   const urduFont = resolveFont('urdu', style.urdu.font_id);
   const englishFont = resolveFont('english', style.english.font_id);
   const referenceEnglishFont = resolveFont('english', style.reference.font_id);
   const referenceArabicFont = resolveFont('arabic', style.reference.arabic_font_id);
 
-  const backgroundStyle: React.CSSProperties = (() => {
-    if (bg.type === 'image') {
-      return {
-        backgroundImage: `url(${bg.value})`,
-        backgroundSize: 'cover',
-        backgroundPosition: 'center',
-      };
-    }
-    if (bg.type === 'gradient') return { backgroundImage: bg.value };
-    return { backgroundColor: bg.value };
-  })();
+  const backgroundStyle = backgroundCss(style.background);
 
   return (
     <div

--- a/src/components/ayat-hadith-designer/design-panel.tsx
+++ b/src/components/ayat-hadith-designer/design-panel.tsx
@@ -1,5 +1,6 @@
+import { CheckCircle } from 'lucide-react';
 import {
-  Input,
+  ColorInput,
   Label,
   Select,
   SelectContent,
@@ -8,9 +9,35 @@ import {
   SelectValue,
   Slider,
 } from '@/components/ui';
-import { BACKGROUNDS, FONTS } from '@/constants';
-import type { AyatHadithReferenceStyle, AyatHadithStyle } from '@/types';
+import {
+  DEFAULT_CUSTOM_COLOR,
+  DEFAULT_GRADIENT_ANGLE,
+  DEFAULT_GRADIENT_FROM,
+  DEFAULT_GRADIENT_TO,
+  FONTS,
+} from '@/constants';
+import {
+  SupabaseBuckets,
+  SupabaseFolders,
+  type AyatHadithBackground,
+  type AyatHadithReferenceStyle,
+  type AyatHadithStyle,
+} from '@/types';
 import { cn } from '@/utils';
+import { gradientCss } from './helpers';
+import { ImageTile } from './image-tile';
+import { useBackgroundImages } from './use-background-images';
+
+const ACTIVE_RING = 'border-primary ring-2 ring-primary/40';
+const INACTIVE_RING = 'border-transparent hover:border-muted-foreground/50';
+
+function SelectedBadge() {
+  return (
+    <div className='absolute top-1 right-1 bg-primary text-primary-foreground rounded-full p-0.5 shadow'>
+      <CheckCircle className='h-3.5 w-3.5' />
+    </div>
+  );
+}
 
 interface DesignPanelProps {
   style: AyatHadithStyle;
@@ -28,77 +55,173 @@ export function DesignPanel({
   showReference,
 }: DesignPanelProps) {
   const update = (patch: Partial<AyatHadithStyle>) => onChange({ ...style, ...patch });
+  const setBackground = (background: AyatHadithBackground) => update({ background });
 
-  const images = BACKGROUNDS.filter(b => b.type === 'image');
-  const colors = BACKGROUNDS.filter(b => b.type === 'color');
-  const gradients = BACKGROUNDS.filter(b => b.type === 'gradient');
+  const bg = style.background;
+  const colorValue = bg.type === 'color' ? bg.color : DEFAULT_CUSTOM_COLOR;
+  const gradientFrom = bg.type === 'gradient' ? bg.from : DEFAULT_GRADIENT_FROM;
+  const gradientTo = bg.type === 'gradient' ? bg.to : DEFAULT_GRADIENT_TO;
+  const gradientAngle = bg.type === 'gradient' ? bg.angle : DEFAULT_GRADIENT_ANGLE;
 
-  const renderTile = (bg: (typeof BACKGROUNDS)[number]) => {
-    const bgStyle =
-      bg.type === 'image'
-        ? { backgroundImage: `url(${bg.value})`, backgroundSize: 'cover' }
-        : bg.type === 'gradient'
-          ? { backgroundImage: bg.value }
-          : { backgroundColor: bg.value };
-    return (
-      <button
-        key={bg.id}
-        type='button'
-        onClick={() => update({ background_id: bg.id })}
-        className={cn(
-          'aspect-video rounded border-2 transition cursor-pointer',
-          style.background_id === bg.id
-            ? 'border-primary ring-2 ring-primary/40'
-            : 'border-transparent hover:border-muted-foreground/50'
-        )}
-        style={bgStyle}
-        title={bg.label}
-      />
-    );
-  };
+  const { images, loading: imagesLoading, error: imagesError } = useBackgroundImages();
 
   return (
     <div className='space-y-6'>
-      <section className='space-y-3'>
+      <section className='space-y-4'>
         <Label className='text-sm font-semibold'>Background</Label>
 
         <div className='space-y-1.5'>
           <Label className='text-xs text-muted-foreground'>Images</Label>
-          <div className='grid grid-cols-3 gap-2'>{images.map(renderTile)}</div>
+          {imagesLoading ? (
+            <div className='grid grid-cols-3 gap-2'>
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div key={i} className='aspect-video rounded bg-muted animate-pulse' />
+              ))}
+            </div>
+          ) : imagesError ? (
+            <p className='text-xs text-destructive'>{imagesError}</p>
+          ) : images.length === 0 ? (
+            <p className='text-xs text-muted-foreground'>
+              No images available. Upload images to the{' '}
+              <span className='font-mono'>{SupabaseFolders.AyatHadithBackgrounds}</span> folder in
+              the <span className='font-mono'>{SupabaseBuckets.Assets}</span> bucket.
+            </p>
+          ) : (
+            <div className='grid grid-cols-3 gap-2'>
+              {images.map(img => (
+                <ImageTile
+                  key={img.url}
+                  image={img}
+                  selected={bg.type === 'image' && bg.url === img.url}
+                  onSelect={() => setBackground({ type: 'image', url: img.url })}
+                />
+              ))}
+            </div>
+          )}
         </div>
 
-        <div className='space-y-1.5'>
-          <Label className='text-xs text-muted-foreground'>Colors</Label>
-          <div className='grid grid-cols-3 gap-2'>{colors.map(renderTile)}</div>
+        <div className='space-y-2'>
+          <Label className='text-xs text-muted-foreground'>Solid color</Label>
+          <button
+            type='button'
+            onClick={() => setBackground({ type: 'color', color: colorValue })}
+            className={cn(
+              'relative w-full aspect-[3/1] rounded border-2 transition cursor-pointer',
+              bg.type === 'color' ? ACTIVE_RING : INACTIVE_RING
+            )}
+            style={{ backgroundColor: colorValue }}
+            title='Use solid color'
+          >
+            {bg.type === 'color' && <SelectedBadge />}
+          </button>
+          <div className='space-y-1'>
+            <Label className='text-[10px] text-muted-foreground uppercase tracking-wide'>
+              Color
+            </Label>
+            <ColorInput
+              value={colorValue}
+              onChange={v => setBackground({ type: 'color', color: v })}
+              className='h-9 w-full p-1'
+            />
+          </div>
         </div>
 
-        <div className='space-y-1.5'>
-          <Label className='text-xs text-muted-foreground'>Gradients</Label>
-          <div className='grid grid-cols-3 gap-2'>{gradients.map(renderTile)}</div>
+        <div className='space-y-2'>
+          <Label className='text-xs text-muted-foreground'>Gradient</Label>
+          <button
+            type='button'
+            onClick={() =>
+              setBackground({
+                type: 'gradient',
+                from: gradientFrom,
+                to: gradientTo,
+                angle: gradientAngle,
+              })
+            }
+            className={cn(
+              'relative w-full aspect-[3/1] rounded border-2 transition cursor-pointer',
+              bg.type === 'gradient' ? ACTIVE_RING : INACTIVE_RING
+            )}
+            style={{ backgroundImage: gradientCss(gradientFrom, gradientTo, gradientAngle) }}
+            title='Use gradient'
+          >
+            {bg.type === 'gradient' && <SelectedBadge />}
+          </button>
+          <div className='flex items-center gap-3'>
+            <div className='space-y-1 flex-1'>
+              <Label className='text-[10px] text-muted-foreground uppercase tracking-wide'>
+                From
+              </Label>
+              <ColorInput
+                value={gradientFrom}
+                onChange={v =>
+                  setBackground({
+                    type: 'gradient',
+                    from: v,
+                    to: gradientTo,
+                    angle: gradientAngle,
+                  })
+                }
+                className='h-9 w-full p-1'
+              />
+            </div>
+            <div className='space-y-1 flex-1'>
+              <Label className='text-[10px] text-muted-foreground uppercase tracking-wide'>
+                To
+              </Label>
+              <ColorInput
+                value={gradientTo}
+                onChange={v =>
+                  setBackground({
+                    type: 'gradient',
+                    from: gradientFrom,
+                    to: v,
+                    angle: gradientAngle,
+                  })
+                }
+                className='h-9 w-full p-1'
+              />
+            </div>
+          </div>
+          <div className='space-y-1'>
+            <Label className='text-[10px] text-muted-foreground uppercase tracking-wide'>
+              Angle: {gradientAngle}°
+            </Label>
+            <Slider
+              min={0}
+              max={360}
+              step={1}
+              value={[gradientAngle]}
+              onValueChange={v =>
+                setBackground({
+                  type: 'gradient',
+                  from: gradientFrom,
+                  to: gradientTo,
+                  angle: v[0],
+                })
+              }
+            />
+          </div>
         </div>
       </section>
 
       <section className='space-y-2'>
-        <Label>Overlay</Label>
-        <div className='flex items-center gap-3'>
-          <Input
-            type='color'
-            value={style.overlay_color}
-            onChange={e => update({ overlay_color: e.target.value })}
-            className='h-9 w-14 p-1'
+        <Label className='text-sm font-semibold'>Overlay</Label>
+        <ColorPickerField
+          value={style.overlay_color}
+          onChange={v => update({ overlay_color: v })}
+        />
+        <div className='space-y-2'>
+          <Label className='text-xs text-muted-foreground'>
+            Opacity: {Math.round(style.overlay_opacity * 100)}%
+          </Label>
+          <Slider
+            min={0}
+            max={100}
+            step={1}
+            value={[style.overlay_opacity * 100]}
+            onValueChange={v => update({ overlay_opacity: v[0] / 100 })}
           />
-          <div className='flex-1'>
-            <Slider
-              min={0}
-              max={100}
-              step={1}
-              value={[style.overlay_opacity * 100]}
-              onValueChange={v => update({ overlay_opacity: v[0] / 100 })}
-            />
-          </div>
-          <span className='text-xs text-muted-foreground w-10 text-right'>
-            {Math.round(style.overlay_opacity * 100)}%
-          </span>
         </div>
       </section>
 
@@ -137,6 +260,75 @@ export function DesignPanel({
   );
 }
 
+interface FontSelectProps {
+  label: string;
+  category: 'arabic' | 'urdu' | 'english';
+  value: string;
+  onChange: (id: string) => void;
+}
+
+function FontSelect({ label, category, value, onChange }: FontSelectProps) {
+  return (
+    <div className='space-y-2'>
+      <Label className='text-xs text-muted-foreground'>{label}</Label>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger className='w-full'>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {FONTS[category].map(f => (
+            <SelectItem key={f.id} value={f.id}>
+              {f.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+interface SizeSliderProps {
+  size: number;
+  onChange: (size: number) => void;
+}
+
+function SizeSlider({ size, onChange }: SizeSliderProps) {
+  return (
+    <div className='space-y-2'>
+      <Label className='text-xs text-muted-foreground'>Size: {size}px</Label>
+      <Slider min={16} max={200} step={2} value={[size]} onValueChange={v => onChange(v[0])} />
+    </div>
+  );
+}
+
+interface ColorPickerFieldProps {
+  value: string;
+  onChange: (color: string) => void;
+}
+
+function ColorPickerField({ value, onChange }: ColorPickerFieldProps) {
+  return (
+    <div className='space-y-1'>
+      <Label className='text-[10px] text-muted-foreground uppercase tracking-wide'>Color</Label>
+      <ColorInput value={value} onChange={onChange} className='h-9 w-full p-1' />
+    </div>
+  );
+}
+
+interface LineHeightSliderProps {
+  value: number;
+  onChange: (value: number) => void;
+}
+
+function LineHeightSlider({ value, onChange }: LineHeightSliderProps) {
+  return (
+    <div className='space-y-2'>
+      <Label className='text-xs text-muted-foreground'>Line spacing: {value.toFixed(1)}</Label>
+      <Slider min={1} max={3} step={0.1} value={[value]} onValueChange={v => onChange(v[0])} />
+    </div>
+  );
+}
+
 interface ReferenceStyleControlsProps {
   style: AyatHadithReferenceStyle;
   onChange: (next: AyatHadithReferenceStyle) => void;
@@ -147,73 +339,25 @@ function ReferenceStyleControls({ style, onChange }: ReferenceStyleControlsProps
     <section className='space-y-3 border-t pt-4'>
       <Label className='text-sm font-semibold'>Reference</Label>
       <div className='grid grid-cols-2 gap-3'>
-        <div className='space-y-2'>
-          <Label className='text-xs text-muted-foreground'>Arabic font</Label>
-          <Select
-            value={style.arabic_font_id}
-            onValueChange={v => onChange({ ...style, arabic_font_id: v })}
-          >
-            <SelectTrigger className='w-full'>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {FONTS.arabic.map(f => (
-                <SelectItem key={f.id} value={f.id}>
-                  {f.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className='space-y-2'>
-          <Label className='text-xs text-muted-foreground'>English font</Label>
-          <Select value={style.font_id} onValueChange={v => onChange({ ...style, font_id: v })}>
-            <SelectTrigger className='w-full'>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {FONTS.english.map(f => (
-                <SelectItem key={f.id} value={f.id}>
-                  {f.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      </div>
-      <div className='flex items-center gap-3'>
-        <div className='flex-1 space-y-2'>
-          <Label className='text-xs text-muted-foreground'>Size: {style.size}px</Label>
-          <Slider
-            min={16}
-            max={200}
-            step={2}
-            value={[style.size]}
-            onValueChange={v => onChange({ ...style, size: v[0] })}
-          />
-        </div>
-        <div className='space-y-2'>
-          <Label className='text-xs text-muted-foreground'>Color</Label>
-          <Input
-            type='color'
-            value={style.color}
-            onChange={e => onChange({ ...style, color: e.target.value })}
-            className='h-9 w-14 p-1'
-          />
-        </div>
-      </div>
-      <div className='space-y-2'>
-        <Label className='text-xs text-muted-foreground'>
-          Line spacing: {style.line_height.toFixed(1)}
-        </Label>
-        <Slider
-          min={1}
-          max={3}
-          step={0.1}
-          value={[style.line_height]}
-          onValueChange={v => onChange({ ...style, line_height: v[0] })}
+        <FontSelect
+          label='Arabic font'
+          category='arabic'
+          value={style.arabic_font_id}
+          onChange={v => onChange({ ...style, arabic_font_id: v })}
+        />
+        <FontSelect
+          label='English font'
+          category='english'
+          value={style.font_id}
+          onChange={v => onChange({ ...style, font_id: v })}
         />
       </div>
+      <SizeSlider size={style.size} onChange={v => onChange({ ...style, size: v })} />
+      <ColorPickerField value={style.color} onChange={v => onChange({ ...style, color: v })} />
+      <LineHeightSlider
+        value={style.line_height}
+        onChange={v => onChange({ ...style, line_height: v })}
+      />
     </section>
   );
 }
@@ -233,59 +377,21 @@ interface TextStyleControlsProps {
 }
 
 function TextStyleControls({ label, category, style, onChange }: TextStyleControlsProps) {
-  const fontOptions = FONTS[category];
-
   return (
     <section className='space-y-3 border-t pt-4'>
       <Label className='text-sm font-semibold'>{label}</Label>
-      <div className='space-y-2'>
-        <Label className='text-xs text-muted-foreground'>Font</Label>
-        <Select value={style.font_id} onValueChange={v => onChange({ ...style, font_id: v })}>
-          <SelectTrigger className='w-full'>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {fontOptions.map(f => (
-              <SelectItem key={f.id} value={f.id}>
-                {f.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-      <div className='flex items-center gap-3'>
-        <div className='flex-1 space-y-2'>
-          <Label className='text-xs text-muted-foreground'>Size: {style.size}px</Label>
-          <Slider
-            min={16}
-            max={200}
-            step={2}
-            value={[style.size]}
-            onValueChange={v => onChange({ ...style, size: v[0] })}
-          />
-        </div>
-        <div className='space-y-2'>
-          <Label className='text-xs text-muted-foreground'>Color</Label>
-          <Input
-            type='color'
-            value={style.color}
-            onChange={e => onChange({ ...style, color: e.target.value })}
-            className='h-9 w-14 p-1'
-          />
-        </div>
-      </div>
-      <div className='space-y-2'>
-        <Label className='text-xs text-muted-foreground'>
-          Line spacing: {style.line_height.toFixed(1)}
-        </Label>
-        <Slider
-          min={1}
-          max={3}
-          step={0.1}
-          value={[style.line_height]}
-          onValueChange={v => onChange({ ...style, line_height: v[0] })}
-        />
-      </div>
+      <FontSelect
+        label='Font'
+        category={category}
+        value={style.font_id}
+        onChange={v => onChange({ ...style, font_id: v })}
+      />
+      <SizeSlider size={style.size} onChange={v => onChange({ ...style, size: v })} />
+      <ColorPickerField value={style.color} onChange={v => onChange({ ...style, color: v })} />
+      <LineHeightSlider
+        value={style.line_height}
+        onChange={v => onChange({ ...style, line_height: v })}
+      />
     </section>
   );
 }

--- a/src/components/ayat-hadith-designer/helpers.ts
+++ b/src/components/ayat-hadith-designer/helpers.ts
@@ -1,7 +1,23 @@
-import { BACKGROUNDS, FONTS, type BackgroundPreset, type FontOption } from '@/constants';
+import type { CSSProperties } from 'react';
+import { FONTS, type FontOption } from '@/constants';
+import type { AyatHadithBackground } from '@/types';
 
-export function resolveBackground(id: string): BackgroundPreset {
-  return BACKGROUNDS.find(b => b.id === id) ?? BACKGROUNDS[0];
+export function gradientCss(from: string, to: string, angle: number): string {
+  return `linear-gradient(${angle}deg, ${from} 0%, ${to} 100%)`;
+}
+
+export function backgroundCss(bg: AyatHadithBackground): CSSProperties {
+  if (bg.type === 'image') {
+    return {
+      backgroundImage: `url(${bg.url})`,
+      backgroundSize: 'cover',
+      backgroundPosition: 'center',
+    };
+  }
+  if (bg.type === 'gradient') {
+    return { backgroundImage: gradientCss(bg.from, bg.to, bg.angle) };
+  }
+  return { backgroundColor: bg.color };
 }
 
 export function resolveFont(category: 'arabic' | 'urdu' | 'english', id: string): FontOption {

--- a/src/components/ayat-hadith-designer/image-tile.tsx
+++ b/src/components/ayat-hadith-designer/image-tile.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { CheckCircle, Loader2 } from 'lucide-react';
+import { cn } from '@/utils';
+import type { BackgroundImage } from './use-background-images';
+
+interface ImageTileProps {
+  image: BackgroundImage;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+const activeRing = 'border-primary ring-2 ring-primary/40';
+const inactiveRing = 'border-transparent hover:border-muted-foreground/50';
+
+export function ImageTile({ image, selected, onSelect }: ImageTileProps) {
+  const [status, setStatus] = useState<'loading' | 'loaded' | 'error'>('loading');
+
+  return (
+    <button
+      type='button'
+      onClick={onSelect}
+      className={cn(
+        'relative aspect-video rounded border-2 overflow-hidden bg-muted transition cursor-pointer',
+        selected ? activeRing : inactiveRing
+      )}
+      title={image.name}
+    >
+      <img
+        src={image.url}
+        alt={image.name}
+        loading='lazy'
+        onLoad={() => setStatus('loaded')}
+        onError={() => setStatus('error')}
+        className={cn(
+          'absolute inset-0 w-full h-full object-cover transition-opacity',
+          status === 'loaded' ? 'opacity-100' : 'opacity-0'
+        )}
+      />
+      {status === 'loading' && (
+        <div className='absolute inset-0 flex items-center justify-center'>
+          <Loader2 className='h-4 w-4 animate-spin text-muted-foreground' />
+        </div>
+      )}
+      {status === 'error' && (
+        <div className='absolute inset-0 flex items-center justify-center text-[10px] text-destructive px-1 text-center'>
+          Failed to load
+        </div>
+      )}
+      {selected && (
+        <div className='absolute top-1 right-1 bg-primary text-primary-foreground rounded-full p-0.5 shadow'>
+          <CheckCircle className='h-3.5 w-3.5' />
+        </div>
+      )}
+    </button>
+  );
+}

--- a/src/components/ayat-hadith-designer/use-background-images.ts
+++ b/src/components/ayat-hadith-designer/use-background-images.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { listFiles } from '@/lib/supabase/helpers';
+import { SupabaseBuckets, SupabaseFolders } from '@/types';
+
+export interface BackgroundImage {
+  name: string;
+  url: string;
+}
+
+const SUPPORTED_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp'];
+
+/**
+ * Fetches the list of background images from the Supabase
+ * `assets/ayat-hadith-backgrounds` folder, sorted alphabetically by filename.
+ */
+export function useBackgroundImages() {
+  const [images, setImages] = useState<BackgroundImage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    listFiles(SupabaseBuckets.Assets, SupabaseFolders.AyatHadithBackgrounds)
+      .then(files => {
+        if (cancelled) return;
+        const filtered = files
+          .filter(f => {
+            const ext = f.name.toLowerCase().split('.').pop();
+            return SUPPORTED_EXTENSIONS.includes(ext || '');
+          })
+          .sort((a, b) => a.name.localeCompare(b.name));
+        setImages(filtered);
+      })
+      .catch(err => {
+        console.error('Failed to load background images:', err);
+        if (!cancelled) setError('Failed to load images');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { images, loading, error };
+}

--- a/src/components/ui/color-input.tsx
+++ b/src/components/ui/color-input.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from 'react';
+import { Input } from './input';
+
+interface ColorInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  className?: string;
+}
+
+/**
+ * Color picker that coalesces rapid drag events through requestAnimationFrame,
+ * so the parent re-renders at most once per frame instead of on every event.
+ */
+export function ColorInput({ value, onChange, className }: ColorInputProps) {
+  const [local, setLocal] = useState(value);
+  const rafRef = useRef<number | null>(null);
+  const pendingRef = useRef(value);
+  const externalRef = useRef(value);
+
+  useEffect(() => {
+    if (value !== externalRef.current) {
+      externalRef.current = value;
+      setLocal(value);
+    }
+  }, [value]);
+
+  useEffect(
+    () => () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    },
+    []
+  );
+
+  return (
+    <Input
+      type='color'
+      value={local}
+      onChange={e => {
+        const next = e.target.value;
+        setLocal(next);
+        pendingRef.current = next;
+        if (rafRef.current === null) {
+          rafRef.current = requestAnimationFrame(() => {
+            rafRef.current = null;
+            externalRef.current = pendingRef.current;
+            onChange(pendingRef.current);
+          });
+        }
+      }}
+      className={className}
+    />
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -28,3 +28,4 @@ export * from './checkbox';
 export * from './theme-toggle';
 export * from './validation-feedback';
 export * from './predesigned-image-selector';
+export * from './color-input';

--- a/src/constants/slide-design.ts
+++ b/src/constants/slide-design.ts
@@ -1,67 +1,7 @@
-import bg01 from '@/assets/backgrounds/01.jpeg';
-import bg02 from '@/assets/backgrounds/02.jpeg';
-import bg03 from '@/assets/backgrounds/03.jpeg';
-import bg04 from '@/assets/backgrounds/04.jpeg';
-import bg05 from '@/assets/backgrounds/05.jpeg';
-
-export type BackgroundType = 'image' | 'color' | 'gradient';
-
-export interface BackgroundPreset {
-  id: string;
-  type: BackgroundType;
-  value: string;
-  label: string;
-}
-
-export const BACKGROUNDS: BackgroundPreset[] = [
-  { id: 'img-01', type: 'image', value: bg01, label: 'Image 1' },
-  { id: 'img-02', type: 'image', value: bg02, label: 'Image 2' },
-  { id: 'img-03', type: 'image', value: bg03, label: 'Image 3' },
-  { id: 'img-04', type: 'image', value: bg04, label: 'Image 4' },
-  { id: 'img-05', type: 'image', value: bg05, label: 'Image 5' },
-  { id: 'color-emerald', type: 'color', value: '#064e3b', label: 'Deep Emerald' },
-  { id: 'color-navy', type: 'color', value: '#0c1f3d', label: 'Navy' },
-  { id: 'color-maroon', type: 'color', value: '#4a1c1c', label: 'Maroon' },
-  { id: 'color-charcoal', type: 'color', value: '#1a1a1a', label: 'Charcoal' },
-  { id: 'color-indigo', type: 'color', value: '#1e1b4b', label: 'Indigo' },
-  { id: 'color-cream', type: 'color', value: '#fef3c7', label: 'Cream' },
-  {
-    id: 'grad-sunset',
-    type: 'gradient',
-    value: 'linear-gradient(135deg, #f97316 0%, #dc2626 100%)',
-    label: 'Sunset',
-  },
-  {
-    id: 'grad-ocean',
-    type: 'gradient',
-    value: 'linear-gradient(135deg, #0891b2 0%, #1e3a8a 100%)',
-    label: 'Ocean',
-  },
-  {
-    id: 'grad-emerald',
-    type: 'gradient',
-    value: 'linear-gradient(135deg, #059669 0%, #064e3b 100%)',
-    label: 'Emerald',
-  },
-  {
-    id: 'grad-royal',
-    type: 'gradient',
-    value: 'linear-gradient(135deg, #7c3aed 0%, #1e1b4b 100%)',
-    label: 'Royal',
-  },
-  {
-    id: 'grad-dusk',
-    type: 'gradient',
-    value: 'linear-gradient(135deg, #be185d 0%, #1e1b4b 100%)',
-    label: 'Dusk',
-  },
-  {
-    id: 'grad-midnight',
-    type: 'gradient',
-    value: 'linear-gradient(135deg, #0f172a 0%, #334155 100%)',
-    label: 'Midnight',
-  },
-];
+export const DEFAULT_CUSTOM_COLOR = '#064e3b';
+export const DEFAULT_GRADIENT_FROM = '#f97316';
+export const DEFAULT_GRADIENT_TO = '#dc2626';
+export const DEFAULT_GRADIENT_ANGLE = 135;
 
 export interface FontOption {
   id: string;
@@ -97,7 +37,7 @@ export const CANVAS_DIMENSIONS: Record<'landscape' | 'portrait' | 'mobile', [num
 };
 
 export const DEFAULT_STYLE = {
-  background_id: 'img-01',
+  background: { type: 'color' as const, color: DEFAULT_CUSTOM_COLOR },
   overlay_color: '#000000',
   overlay_opacity: 0.4,
   arabic: { font_id: 'amiri', size: 72, color: '#ffffff', line_height: 1.6 },

--- a/src/lib/zod.ts
+++ b/src/lib/zod.ts
@@ -217,8 +217,19 @@ const referenceStyleSchema = z.object({
   line_height: z.number().min(0.8).max(4),
 });
 
+const backgroundSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('image'), url: z.string() }),
+  z.object({ type: z.literal('color'), color: z.string() }),
+  z.object({
+    type: z.literal('gradient'),
+    from: z.string(),
+    to: z.string(),
+    angle: z.number().min(0).max(360),
+  }),
+]);
+
 const ayatHadithStyleSchema = z.object({
-  background_id: z.string(),
+  background: backgroundSchema,
   overlay_color: z.string(),
   overlay_opacity: z.number().min(0).max(1),
   arabic: textStyleSchema,

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -24,6 +24,7 @@ export enum SupabaseBuckets {
 
 export enum SupabaseFolders {
   PredesignedPosts = 'predesigned-posts',
+  AyatHadithBackgrounds = 'ayat-hadith-backgrounds',
 }
 
 export type MemberRole = 'admin' | 'moderator';
@@ -94,8 +95,13 @@ export interface AyatHadithReferenceStyle extends AyatHadithTextStyle {
   arabic_font_id: string;
 }
 
+export type AyatHadithBackground =
+  | { type: 'image'; url: string }
+  | { type: 'color'; color: string }
+  | { type: 'gradient'; from: string; to: string; angle: number };
+
 export interface AyatHadithStyle {
-  background_id: string;
+  background: AyatHadithBackground;
   overlay_color: string;
   overlay_opacity: number;
   arabic: AyatHadithTextStyle;


### PR DESCRIPTION
## Summary
- Replaces the fixed preset palette (5 bundled images + 6 colors + 6 gradients) with **dynamic images from Supabase storage** plus **custom solid color** and **custom gradient** (from/to + angle).
- Background discriminator changed from `style.background_id: string` to `style.background: { type: 'image'; url } | { type: 'color'; color } | { type: 'gradient'; from; to; angle }`. Old saved slides fall back to the default solid color until re-saved (intentional break, per discussion).
- Per-image loading spinner, fade-in on load, `CheckCircle` badge on the active selection.
- `ColorInput` wrapper coalesces native color-picker drag events through `requestAnimationFrame`, so the heavy 1920×1080 Canvas re-renders at most once per frame (was very laggy before).
- Extracted reusables: `@/components/ui/color-input.tsx`, `ayat-hadith-designer/image-tile.tsx`, `ayat-hadith-designer/use-background-images.ts`. Inline form helpers (`FontSelect`, `SizeSlider`, `ColorPickerField`, `LineHeightSlider`, `SelectedBadge`) dedupe the text/reference/overlay sections.
- Consistent vertical layout across all swatch+picker blocks (Solid color, Gradient, Overlay, Arabic/Urdu/English text, Reference).

## Setup
Upload `.jpg/.jpeg/.png/.webp` files to the `assets` bucket under the new `ayat-hadith-backgrounds/` folder. They appear in the designer on next load — no rebuild needed.

## Test plan
- [ ] Open designer → image tiles fetch from `assets/ayat-hadith-backgrounds`, each shows a spinner until loaded, fades in, badge appears on the selected one
- [ ] Empty folder → friendly "upload images to ..." message
- [ ] Pick a solid color → preview tile + picker stay in sync, badge appears
- [ ] Pick a gradient (from / to / angle slider) → preview tile + Canvas update smoothly
- [ ] Drag color sliders aggressively → no visible lag in the Canvas
- [ ] Adjust Overlay color/opacity, text colors (Arabic/Urdu/English), Reference color → still applies correctly
- [ ] Save a new slide → image renders in the saved PNG snapshot
- [ ] Edit a slide saved before this branch → falls back to default solid color, can re-save cleanly