### PR TITLE
feat: open screen assignment modal after creating a resource

### DIFF
--- a/src/components/ayat-hadith-designer/image-tile.tsx
+++ b/src/components/ayat-hadith-designer/image-tile.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { CheckCircle, Loader2 } from 'lucide-react';
+import { CheckCircle } from 'lucide-react';
+import { RemoteImage } from '@/components/ui';
 import { cn } from '@/utils';
 import type { BackgroundImage } from './use-background-images';
 
@@ -13,41 +13,19 @@ const activeRing = 'border-primary ring-2 ring-primary/40';
 const inactiveRing = 'border-transparent hover:border-muted-foreground/50';
 
 export function ImageTile({ image, selected, onSelect }: ImageTileProps) {
-  const [status, setStatus] = useState<'loading' | 'loaded' | 'error'>('loading');
-
   return (
     <button
       type='button'
       onClick={onSelect}
       className={cn(
-        'relative aspect-video rounded border-2 overflow-hidden bg-muted transition cursor-pointer',
+        'relative aspect-video rounded border-2 overflow-hidden transition cursor-pointer',
         selected ? activeRing : inactiveRing
       )}
       title={image.name}
     >
-      <img
-        src={image.url}
-        alt={image.name}
-        loading='lazy'
-        onLoad={() => setStatus('loaded')}
-        onError={() => setStatus('error')}
-        className={cn(
-          'absolute inset-0 w-full h-full object-cover transition-opacity',
-          status === 'loaded' ? 'opacity-100' : 'opacity-0'
-        )}
-      />
-      {status === 'loading' && (
-        <div className='absolute inset-0 flex items-center justify-center'>
-          <Loader2 className='h-4 w-4 animate-spin text-muted-foreground' />
-        </div>
-      )}
-      {status === 'error' && (
-        <div className='absolute inset-0 flex items-center justify-center text-[10px] text-destructive px-1 text-center'>
-          Failed to load
-        </div>
-      )}
+      <RemoteImage src={image.url} alt={image.name} containerClassName='absolute inset-0' />
       {selected && (
-        <div className='absolute top-1 right-1 bg-primary text-primary-foreground rounded-full p-0.5 shadow'>
+        <div className='absolute top-1 right-1 bg-primary text-primary-foreground rounded-full p-0.5 shadow z-10'>
           <CheckCircle className='h-3.5 w-3.5' />
         </div>
       )}

--- a/src/components/modals/announcement-modal.tsx
+++ b/src/components/modals/announcement-modal.tsx
@@ -20,7 +20,7 @@ import { toast } from 'sonner';
 type AnnouncementModalProps = {
   isOpen: boolean;
   onClose: () => void;
-  onSuccess: () => void;
+  onSuccess: (createdAnnouncement?: Announcement) => void;
   initialData?: Announcement;
 };
 
@@ -57,11 +57,14 @@ export function AnnouncementModal({
     try {
       setIsSubmitting(true);
       setError(null);
-      await upsertAnnouncement({ ...data, ...(initialData?.id && { id: initialData.id }) });
+      const saved = await upsertAnnouncement({
+        ...data,
+        ...(initialData?.id && { id: initialData.id }),
+      });
       toast.success(`Announcement ${isEdit ? 'updated' : 'created'} successfully`);
 
       reset();
-      onSuccess();
+      onSuccess(isEdit ? undefined : saved);
       onClose();
     } catch (error) {
       console.error('Error saving announcement:', error);

--- a/src/components/modals/event-modal.tsx
+++ b/src/components/modals/event-modal.tsx
@@ -22,7 +22,7 @@ import { toast } from 'sonner';
 interface EventModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSuccess: () => void;
+  onSuccess: (createdEvent?: Event) => void;
   initialData?: Event;
 }
 
@@ -90,12 +90,15 @@ export function EventModal({ isOpen, onClose, onSuccess, initialData }: EventMod
     try {
       setIsSubmitting(true);
       setError(null);
-      await upsertEvent({ ...data, ...(initialData?.id && { id: initialData.id }) });
+      const saved = await upsertEvent({
+        ...data,
+        ...(initialData?.id && { id: initialData.id }),
+      });
       toast.success(`Event ${isEdit ? 'updated' : 'created'} successfully`);
 
       reset();
       setDateTime(undefined);
-      onSuccess();
+      onSuccess(isEdit ? undefined : saved);
       onClose();
     } catch (error) {
       console.error('Error saving event:', error);

--- a/src/components/modals/index.ts
+++ b/src/components/modals/index.ts
@@ -27,9 +27,7 @@ export const HijriModal = lazy(() =>
 export const ScreenModal = lazy(() =>
   import('./screen-modal').then(m => ({ default: m.ScreenModal }))
 );
-export const ScreenAssignmentModal = lazy(() =>
-  import('./screen-assignment-modal').then(m => ({ default: m.ScreenAssignmentModal }))
-);
+export { ScreenAssignmentModal } from './screen-assignment-modal';
 export const YouTubeVideoModal = lazy(() =>
   import('./youtube-video-modal').then(m => ({ default: m.YouTubeVideoModal }))
 );

--- a/src/components/modals/post-modal/index.tsx
+++ b/src/components/modals/post-modal/index.tsx
@@ -14,7 +14,7 @@ import { UploadForm } from './upload-form';
 type PostModalProps = {
   isOpen: boolean;
   onClose: () => void;
-  onSuccess: () => void;
+  onSuccess: (createdPost?: Post) => void;
   initialData?: Post;
   presetOrientation?: PostOrientation;
 };
@@ -137,13 +137,16 @@ export function PostModal({
         imageToUse = new File([blob], fileName, { type: blob.type });
       }
 
-      await upsertPost({ ...data, ...(initialData?.id && { id: initialData.id }) }, imageToUse);
+      const saved = await upsertPost(
+        { ...data, ...(initialData?.id && { id: initialData.id }) },
+        imageToUse
+      );
       toast.success(`Post ${isEdit ? 'updated' : 'created'} successfully`);
 
       reset();
       resetSteps();
       setError(null);
-      onSuccess();
+      onSuccess(isEdit ? undefined : saved);
       onClose();
     } catch {
       setError('Failed to save post. Please try again.');

--- a/src/components/modals/screen-assignment-modal.tsx
+++ b/src/components/modals/screen-assignment-modal.tsx
@@ -22,6 +22,8 @@ type ScreenAssignmentModalProps = {
   contentLabel?: string;
   /** When provided (posts only), restricts which screens can be assigned */
   contentOrientation?: PostOrientation;
+  /** Label for the dismiss button. Defaults to "Cancel". Use "Skip" in creation flows. */
+  dismissLabel?: string;
 };
 
 /** Returns true if the screen's orientation is compatible with the post orientation */
@@ -46,6 +48,7 @@ export function ScreenAssignmentModal({
   contentType,
   contentLabel,
   contentOrientation,
+  dismissLabel = 'Cancel',
 }: ScreenAssignmentModalProps) {
   const [screens, setScreens] = useState<DisplayScreen[]>([]);
   const [selectedScreenIds, setSelectedScreenIds] = useState<Set<string>>(new Set());
@@ -184,7 +187,7 @@ export function ScreenAssignmentModal({
         <DialogFooter>
           <DialogClose asChild>
             <Button type='button' variant='outline'>
-              Cancel
+              {dismissLabel}
             </Button>
           </DialogClose>
           <Button

--- a/src/components/modals/youtube-video-modal.tsx
+++ b/src/components/modals/youtube-video-modal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
+import { Youtube } from 'lucide-react';
 import {
   Button,
   Input,
@@ -9,6 +10,7 @@ import {
   DialogFooter,
   DialogClose,
   Label,
+  RemoteImage,
   Switch,
 } from '@/components/ui';
 import { youtubeVideoSchema, type YouTubeVideoData } from '@/lib/zod';
@@ -35,7 +37,7 @@ function extractVideoId(url: string): string | null {
 type YouTubeVideoModalProps = {
   isOpen: boolean;
   onClose: () => void;
-  onSuccess: () => void;
+  onSuccess: (createdVideo?: YouTubeVideo) => void;
   initialData?: YouTubeVideo;
 };
 
@@ -74,11 +76,14 @@ export function YouTubeVideoModal({
     try {
       setIsSubmitting(true);
       setError(null);
-      await upsertYouTubeVideo({ ...data, ...(initialData?.id && { id: initialData.id }) });
+      const saved = await upsertYouTubeVideo({
+        ...data,
+        ...(initialData?.id && { id: initialData.id }),
+      });
       toast.success(`YouTube video ${isEdit ? 'updated' : 'created'} successfully`);
 
       reset();
-      onSuccess();
+      onSuccess(isEdit ? undefined : saved);
       onClose();
     } catch (error) {
       console.error('Error saving YouTube video:', error);
@@ -91,72 +96,81 @@ export function YouTubeVideoModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={open => !open && onClose()}>
-      <DialogContent className='sm:max-w-[550px]'>
+      <DialogContent className='sm:max-w-[860px]'>
         <DialogHeader>
           <DialogTitle>{isEdit ? 'Edit YouTube Video' : 'Add YouTube Video'}</DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className='space-y-4 pt-4'>
+        <form onSubmit={handleSubmit(onSubmit)} className='pt-4'>
           {error && (
             <div className='bg-destructive/10 border border-destructive/20 text-destructive px-4 py-3 rounded mb-4'>
               {error}
             </div>
           )}
 
-          <div className='space-y-2'>
-            <Label htmlFor='title'>Title</Label>
-            <Input
-              id='title'
-              placeholder='Enter a title for this video'
-              className={errors.title ? 'border-destructive' : ''}
-              {...register('title')}
-            />
-            {errors.title && <p className='text-destructive text-sm'>{errors.title.message}</p>}
-          </div>
+          <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
+            <div className='space-y-4'>
+              <div className='space-y-2'>
+                <Label htmlFor='title'>Title</Label>
+                <Input
+                  id='title'
+                  placeholder='Enter a title for this video'
+                  className={errors.title ? 'border-destructive' : ''}
+                  {...register('title')}
+                />
+                {errors.title && <p className='text-destructive text-sm'>{errors.title.message}</p>}
+              </div>
 
-          <div className='space-y-2'>
-            <Label htmlFor='youtube_url'>YouTube URL</Label>
-            <Input
-              id='youtube_url'
-              placeholder='https://www.youtube.com/watch?v=...'
-              className={errors.youtube_url ? 'border-destructive' : ''}
-              {...register('youtube_url')}
-            />
-            {errors.youtube_url && (
-              <p className='text-destructive text-sm'>{errors.youtube_url.message}</p>
-            )}
-            <p className='text-xs text-muted-foreground'>
-              Paste a YouTube video URL (e.g. youtube.com/watch?v=... or youtu.be/...)
-            </p>
-            {thumbnailVideoId && (
-              <div className='relative rounded-lg overflow-hidden border bg-black'>
-                <img
-                  src={`https://img.youtube.com/vi/${thumbnailVideoId}/hqdefault.jpg`}
-                  alt='Video thumbnail'
-                  className='w-full h-auto object-cover'
+              <div className='space-y-2'>
+                <Label htmlFor='youtube_url'>YouTube URL</Label>
+                <Input
+                  id='youtube_url'
+                  placeholder='https://www.youtube.com/watch?v=...'
+                  className={errors.youtube_url ? 'border-destructive' : ''}
+                  {...register('youtube_url')}
+                />
+                {errors.youtube_url && (
+                  <p className='text-destructive text-sm'>{errors.youtube_url.message}</p>
+                )}
+                <p className='text-xs text-muted-foreground'>
+                  Paste a YouTube video URL (e.g. youtube.com/watch?v=... or youtu.be/...)
+                </p>
+              </div>
+
+              <div className='flex items-center justify-between'>
+                <Label htmlFor='loop_video'>Loop Video</Label>
+                <Controller
+                  name='loop_video'
+                  control={control}
+                  render={({ field }) => (
+                    <Switch
+                      id='loop_video'
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  )}
                 />
               </div>
-            )}
-          </div>
-
-          <div className='flex items-center justify-between rounded-lg border p-3'>
-            <div className='space-y-0.5'>
-              <Label htmlFor='loop_video'>Loop Video</Label>
-              <p className='text-xs text-muted-foreground'>
-                When enabled, video replays on completion. When disabled, slideshow advances to next
-                slide.
-              </p>
             </div>
-            <Controller
-              name='loop_video'
-              control={control}
-              render={({ field }) => (
-                <Switch id='loop_video' checked={field.value} onCheckedChange={field.onChange} />
+
+            <div className='space-y-2'>
+              <Label>Preview</Label>
+              {thumbnailVideoId ? (
+                <RemoteImage
+                  src={`https://img.youtube.com/vi/${thumbnailVideoId}/hqdefault.jpg`}
+                  alt='Video thumbnail'
+                  containerClassName='w-full aspect-video rounded-lg border'
+                />
+              ) : (
+                <div className='relative w-full aspect-video rounded-lg overflow-hidden border bg-muted flex flex-col items-center justify-center gap-2 text-muted-foreground'>
+                  <Youtube className='h-10 w-10' />
+                  <p className='text-xs text-center px-4'>Paste a YouTube URL to see the preview</p>
+                </div>
               )}
-            />
+            </div>
           </div>
 
-          <DialogFooter>
+          <DialogFooter className='mt-6'>
             <DialogClose asChild>
               <Button type='button' variant='outline'>
                 Cancel

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -29,3 +29,4 @@ export * from './theme-toggle';
 export * from './validation-feedback';
 export * from './predesigned-image-selector';
 export * from './color-input';
+export * from './remote-image';

--- a/src/components/ui/predesigned-image-selector.tsx
+++ b/src/components/ui/predesigned-image-selector.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { CheckCircle } from 'lucide-react';
 import { listFiles } from '@/lib/supabase/helpers';
 import { SupabaseBuckets, SupabaseFolders } from '@/types';
+import { RemoteImage } from './remote-image';
 
 type PredesignedImage = {
   id: string;
@@ -103,16 +104,7 @@ export function PredesignedImageSelector({
             }`}
             onClick={() => onImageSelect(image.src)}
           >
-            <div className='aspect-video'>
-              <img
-                src={image.src}
-                alt={image.alt}
-                className='w-full h-full object-cover'
-                onError={e => {
-                  (e.target as HTMLImageElement).style.display = 'none';
-                }}
-              />
-            </div>
+            <RemoteImage src={image.src} alt={image.alt} containerClassName='aspect-video' />
             {selectedImage === image.src && (
               <div className='absolute top-2 right-2 bg-primary text-white rounded-full p-1'>
                 <CheckCircle className='w-4 h-4' />

--- a/src/components/ui/remote-image.tsx
+++ b/src/components/ui/remote-image.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { ImageOff, Loader2 } from 'lucide-react';
+import { cn } from '@/utils';
+
+interface RemoteImageProps {
+  src: string;
+  alt: string;
+  /** Class applied to the absolute-positioned <img>. */
+  className?: string;
+  /** Class applied to the relative-positioned wrapping div. */
+  containerClassName?: string;
+  /** Optional placeholder shown while loading. Default: centered spinner. */
+  placeholder?: React.ReactNode;
+  /** Object-fit applied to the image. Default: cover. */
+  fit?: 'cover' | 'contain';
+  /** Native lazy loading. Default: true. */
+  lazy?: boolean;
+}
+
+/**
+ * Renders a remotely-fetched image with a per-image loading spinner overlay,
+ * fade-in on load, and a fallback icon on error. The wrapper sizes the slot;
+ * the image fills it absolutely.
+ */
+export function RemoteImage({
+  src,
+  alt,
+  className,
+  containerClassName,
+  placeholder,
+  fit = 'cover',
+  lazy = true,
+}: RemoteImageProps) {
+  const [status, setStatus] = useState<'loading' | 'loaded' | 'error'>('loading');
+
+  return (
+    <div className={cn('relative overflow-hidden bg-muted', containerClassName)}>
+      <img
+        src={src}
+        alt={alt}
+        loading={lazy ? 'lazy' : 'eager'}
+        onLoad={() => setStatus('loaded')}
+        onError={() => setStatus('error')}
+        className={cn(
+          'absolute inset-0 w-full h-full transition-opacity',
+          fit === 'cover' ? 'object-cover' : 'object-contain',
+          status === 'loaded' ? 'opacity-100' : 'opacity-0',
+          className
+        )}
+      />
+      {status === 'loading' &&
+        (placeholder ?? (
+          <div className='absolute inset-0 flex items-center justify-center'>
+            <Loader2 className='h-4 w-4 animate-spin text-muted-foreground' />
+          </div>
+        ))}
+      {status === 'error' && (
+        <div className='absolute inset-0 flex items-center justify-center text-muted-foreground'>
+          <ImageOff className='h-4 w-4' />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/app/announcements.tsx
+++ b/src/pages/app/announcements.tsx
@@ -29,6 +29,7 @@ export default function Announcements() {
   const [itemToDelete, setItemToDelete] = useState<Announcement | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [screenAssignItem, setScreenAssignItem] = useState<Announcement | null>(null);
+  const [assignedFromCreate, setAssignedFromCreate] = useState(false);
 
   const [trigger, forceUpdate] = useTrigger();
 
@@ -145,7 +146,14 @@ export default function Announcements() {
       <AnnouncementModal
         isOpen={isModalOpen}
         onClose={handleModalClose}
-        onSuccess={forceUpdate}
+        onSuccess={created => {
+          if (created) {
+            setAssignedFromCreate(true);
+            setScreenAssignItem(created);
+          } else {
+            forceUpdate();
+          }
+        }}
         initialData={selectedItem}
       />
 
@@ -161,10 +169,17 @@ export default function Announcements() {
       {screenAssignItem && (
         <ScreenAssignmentModal
           isOpen={!!screenAssignItem}
-          onClose={() => setScreenAssignItem(null)}
+          onClose={() => {
+            setScreenAssignItem(null);
+            if (assignedFromCreate) {
+              forceUpdate();
+              setAssignedFromCreate(false);
+            }
+          }}
           contentId={screenAssignItem.id}
           contentType='announcements'
           contentLabel={screenAssignItem.description}
+          dismissLabel={assignedFromCreate ? 'Skip' : 'Cancel'}
         />
       )}
     </div>

--- a/src/pages/app/ayat-and-hadith.tsx
+++ b/src/pages/app/ayat-and-hadith.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { deleteAyatAndHadith, getAyatAndHadith } from '@/lib/supabase';
-import type { AyatAndHadith, AyatSource, HadithSource, PostOrientation } from '@/types';
-import { AppRoutes, SURAHS, HADITH_BOOKS } from '@/constants';
+import type { AyatAndHadith } from '@/types';
+import { AppRoutes } from '@/constants';
 import { TableSkeleton } from '@/components/skeletons';
 import {
   DeleteConfirmationModal,
@@ -18,27 +18,13 @@ import {
   OrientationBadge,
   type Column,
 } from '@/components/common';
-import { Badge, Popover, PopoverContent, PopoverTrigger } from '@/components/ui';
+import { Badge, Popover, PopoverContent, PopoverTrigger, RemoteImage } from '@/components/ui';
 import { BookOpen } from 'lucide-react';
 import { useTrigger } from '@/hooks';
 import { toast } from 'sonner';
+import { formatSlideReference, slideToPostOrientation } from '@/utils';
 
 const SLIDE_ORIENTATIONS = ['landscape', 'portrait'] as const;
-
-function formatReference(item: AyatAndHadith): string {
-  if (item.type === 'ayat') {
-    const src = item.source as AyatSource;
-    const surah = SURAHS.find(s => s.number === src.surah);
-    return `Surah ${surah?.name_english ?? src.surah} ${src.surah}:${src.ayah}`;
-  }
-  const src = item.source as HadithSource;
-  const book = HADITH_BOOKS.find(b => b.slug === src.book);
-  return `${book?.name ?? src.book} #${src.hadith_number}`;
-}
-
-function slideToPostOrientation(o: AyatAndHadith['orientation']): PostOrientation {
-  return o === 'landscape' ? 'landscape' : 'portrait';
-}
 
 export default function AyatAndHadithPage() {
   const navigate = useNavigate();
@@ -117,10 +103,10 @@ export default function AyatAndHadithPage() {
         <Popover>
           <PopoverTrigger asChild>
             <button type='button' className='cursor-zoom-in'>
-              <img
+              <RemoteImage
                 src={value as string}
                 alt='Slide preview'
-                className='h-14 w-24 object-cover rounded border'
+                containerClassName='h-14 w-24 rounded border'
               />
             </button>
           </PopoverTrigger>
@@ -145,7 +131,7 @@ export default function AyatAndHadithPage() {
       key: 'id',
       name: 'Reference',
       width: 'w-auto',
-      render: (_, item) => <span>{formatReference(item)}</span>,
+      render: (_, item) => <span>{formatSlideReference(item)}</span>,
     },
     {
       key: 'orientation',
@@ -217,7 +203,7 @@ export default function AyatAndHadithPage() {
         onConfirm={handleDeleteConfirm}
         isDeleting={isDeleting}
         itemType='slide'
-        itemTitle={itemToDelete ? formatReference(itemToDelete) : undefined}
+        itemTitle={itemToDelete ? formatSlideReference(itemToDelete) : undefined}
       />
 
       {screenAssignItem && (
@@ -226,7 +212,7 @@ export default function AyatAndHadithPage() {
           onClose={() => setScreenAssignItem(null)}
           contentId={screenAssignItem.id}
           contentType='ayat_and_hadith'
-          contentLabel={formatReference(screenAssignItem)}
+          contentLabel={formatSlideReference(screenAssignItem)}
           contentOrientation={slideToPostOrientation(screenAssignItem.orientation)}
         />
       )}

--- a/src/pages/app/ayat-hadith-designer.tsx
+++ b/src/pages/app/ayat-hadith-designer.tsx
@@ -8,6 +8,7 @@ import {
   useCanvasSnapshot,
   type ContentState,
 } from '@/components/ayat-hadith-designer';
+import { ScreenAssignmentModal } from '@/components/modals';
 import { AppRoutes, DEFAULT_STYLE, QURAN_TRANSLATIONS } from '@/constants';
 import { getAyatAndHadithById, upsertAyatAndHadith } from '@/lib/supabase';
 import type {
@@ -18,6 +19,7 @@ import type {
   HadithSource,
   ScreenOrientation,
 } from '@/types';
+import { formatSlideReference, slideToPostOrientation } from '@/utils';
 import { toast } from 'sonner';
 import { ArrowLeft, Loader2 } from 'lucide-react';
 
@@ -98,6 +100,7 @@ export default function AyatHadithDesigner() {
   const [isFetching, setIsFetching] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<'content' | 'design'>('content');
+  const [screenAssignTarget, setScreenAssignTarget] = useState<AyatAndHadith | null>(null);
 
   // Redirect to listing if create mode is missing the orientation query param
   useEffect(() => {
@@ -164,7 +167,7 @@ export default function AyatHadithDesigner() {
     setError(null);
     try {
       const blob = await snapshot(canvasRef.current);
-      await upsertAyatAndHadith({
+      const saved = await upsertAyatAndHadith({
         id: initialData?.id,
         type: content.type,
         orientation,
@@ -175,7 +178,11 @@ export default function AyatHadithDesigner() {
         previousImagePath: initialData?.image_path,
       });
       toast.success(`Slide ${isEdit ? 'updated' : 'created'} successfully`);
-      navigate(AppRoutes.AyatAndHadith);
+      if (isEdit) {
+        navigate(AppRoutes.AyatAndHadith);
+      } else {
+        setScreenAssignTarget(saved);
+      }
     } catch (err) {
       console.error('Error saving slide:', err);
       setError((err as Error).message ?? 'Failed to save slide');
@@ -266,6 +273,21 @@ export default function AyatHadithDesigner() {
           </Tabs>
         </div>
       </div>
+
+      {screenAssignTarget && (
+        <ScreenAssignmentModal
+          isOpen={!!screenAssignTarget}
+          onClose={() => {
+            setScreenAssignTarget(null);
+            navigate(AppRoutes.AyatAndHadith);
+          }}
+          contentId={screenAssignTarget.id}
+          contentType='ayat_and_hadith'
+          contentLabel={formatSlideReference(screenAssignTarget)}
+          contentOrientation={slideToPostOrientation(screenAssignTarget.orientation)}
+          dismissLabel='Skip'
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/app/events.tsx
+++ b/src/pages/app/events.tsx
@@ -26,6 +26,7 @@ export default function Events() {
   const [itemToDelete, setItemToDelete] = useState<Event | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [screenAssignItem, setScreenAssignItem] = useState<Event | null>(null);
+  const [assignedFromCreate, setAssignedFromCreate] = useState(false);
 
   const [trigger, forceUpdate] = useTrigger();
 
@@ -163,7 +164,14 @@ export default function Events() {
       <EventModal
         isOpen={isModalOpen}
         onClose={handleModalClose}
-        onSuccess={forceUpdate}
+        onSuccess={created => {
+          if (created) {
+            setAssignedFromCreate(true);
+            setScreenAssignItem(created);
+          } else {
+            forceUpdate();
+          }
+        }}
         initialData={selectedItem}
       />
 
@@ -180,10 +188,17 @@ export default function Events() {
       {screenAssignItem && (
         <ScreenAssignmentModal
           isOpen={!!screenAssignItem}
-          onClose={() => setScreenAssignItem(null)}
+          onClose={() => {
+            setScreenAssignItem(null);
+            if (assignedFromCreate) {
+              forceUpdate();
+              setAssignedFromCreate(false);
+            }
+          }}
           contentId={screenAssignItem.id}
           contentType='events'
           contentLabel={screenAssignItem.title}
+          dismissLabel={assignedFromCreate ? 'Skip' : 'Cancel'}
         />
       )}
     </div>

--- a/src/pages/app/posts.tsx
+++ b/src/pages/app/posts.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/components/common';
 import { FileImage } from 'lucide-react';
 import { useTrigger } from '@/hooks';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui';
+import { Popover, PopoverContent, PopoverTrigger, RemoteImage } from '@/components/ui';
 import { toast } from 'sonner';
 
 const POST_ORIENTATIONS = ['landscape', 'portrait'] as const;
@@ -34,6 +34,7 @@ export default function Posts() {
   const [itemToDelete, setItemToDelete] = useState<Post | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [screenAssignItem, setScreenAssignItem] = useState<Post | null>(null);
+  const [assignedFromCreate, setAssignedFromCreate] = useState(false);
   const [orientationPickerOpen, setOrientationPickerOpen] = useState(false);
   const [pendingOrientation, setPendingOrientation] = useState<PostOrientation | null>(null);
 
@@ -117,10 +118,10 @@ export default function Posts() {
           <Popover>
             <PopoverTrigger asChild>
               <button type='button' className='cursor-zoom-in'>
-                <img
+                <RemoteImage
                   src={value as string}
                   alt='Post preview'
-                  className='h-14 w-24 object-cover rounded border'
+                  containerClassName='h-14 w-24 rounded border'
                 />
               </button>
             </PopoverTrigger>
@@ -199,7 +200,14 @@ export default function Posts() {
       <PostModal
         isOpen={isModalOpen}
         onClose={handleModalClose}
-        onSuccess={forceUpdate}
+        onSuccess={created => {
+          if (created) {
+            setAssignedFromCreate(true);
+            setScreenAssignItem(created);
+          } else {
+            forceUpdate();
+          }
+        }}
         initialData={selectedItem}
         presetOrientation={pendingOrientation ?? undefined}
       />
@@ -225,11 +233,18 @@ export default function Posts() {
       {screenAssignItem && (
         <ScreenAssignmentModal
           isOpen={!!screenAssignItem}
-          onClose={() => setScreenAssignItem(null)}
+          onClose={() => {
+            setScreenAssignItem(null);
+            if (assignedFromCreate) {
+              forceUpdate();
+              setAssignedFromCreate(false);
+            }
+          }}
           contentId={screenAssignItem.id}
           contentType='posts'
           contentLabel={screenAssignItem.title}
           contentOrientation={screenAssignItem.orientation}
+          dismissLabel={assignedFromCreate ? 'Skip' : 'Cancel'}
         />
       )}
     </div>

--- a/src/pages/app/youtube-videos.tsx
+++ b/src/pages/app/youtube-videos.tsx
@@ -30,6 +30,7 @@ export default function YouTubeVideos() {
   const [itemToDelete, setItemToDelete] = useState<YouTubeVideo | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [screenAssignItem, setScreenAssignItem] = useState<YouTubeVideo | null>(null);
+  const [assignedFromCreate, setAssignedFromCreate] = useState(false);
 
   const [trigger, forceUpdate] = useTrigger();
 
@@ -169,7 +170,14 @@ export default function YouTubeVideos() {
       <YouTubeVideoModal
         isOpen={isModalOpen}
         onClose={handleModalClose}
-        onSuccess={forceUpdate}
+        onSuccess={created => {
+          if (created) {
+            setAssignedFromCreate(true);
+            setScreenAssignItem(created);
+          } else {
+            forceUpdate();
+          }
+        }}
         initialData={selectedItem}
       />
 
@@ -185,10 +193,17 @@ export default function YouTubeVideos() {
       {screenAssignItem && (
         <ScreenAssignmentModal
           isOpen={!!screenAssignItem}
-          onClose={() => setScreenAssignItem(null)}
+          onClose={() => {
+            setScreenAssignItem(null);
+            if (assignedFromCreate) {
+              forceUpdate();
+              setAssignedFromCreate(false);
+            }
+          }}
           contentId={screenAssignItem.id}
           contentType='youtube_videos'
           contentLabel={screenAssignItem.title}
+          dismissLabel={assignedFromCreate ? 'Skip' : 'Cancel'}
         />
       )}
     </div>

--- a/src/utils/ayat-hadith.ts
+++ b/src/utils/ayat-hadith.ts
@@ -1,0 +1,17 @@
+import { HADITH_BOOKS, SURAHS } from '@/constants';
+import type { AyatAndHadith, AyatSource, HadithSource, PostOrientation } from '@/types';
+
+export function formatSlideReference(item: AyatAndHadith): string {
+  if (item.type === 'ayat') {
+    const src = item.source as AyatSource;
+    const surah = SURAHS.find(s => s.number === src.surah);
+    return `Surah ${surah?.name_english ?? src.surah} ${src.surah}:${src.ayah}`;
+  }
+  const src = item.source as HadithSource;
+  const book = HADITH_BOOKS.find(b => b.slug === src.book);
+  return `${book?.name ?? src.book} #${src.hadith_number}`;
+}
+
+export function slideToPostOrientation(o: AyatAndHadith['orientation']): PostOrientation {
+  return o === 'landscape' ? 'landscape' : 'portrait';
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -13,3 +13,4 @@ export * from './online-status';
 export * from './prayer-card-images';
 export * from './image-validation';
 export * from './password-strength';
+export * from './ayat-hadith';


### PR DESCRIPTION
## Summary
- After creating a post, YouTube video, announcement, event, or ayat/hadith slide, the screen assignment modal now opens for the new record so admins can put it on a screen without an extra navigation step. Edits and the existing row-action "Screens" button are unchanged.
- The screen modal is no longer lazy-loaded — that was the cause of the fullscreen "PrayerBox" loader flashing into view every time the modal opened (route-level Suspense fallback).
- List refetch is deferred to the screen modal's close so the underlying table doesn't go into skeleton state under the modal during the create flow. Edits still refetch inline; row-action opens skip the refetch like before.
- Added a `dismissLabel` prop on the screen modal; pages pass **"Skip"** in the create flow and keep **"Cancel"** elsewhere.
- YouTube video modal redesigned: 2-column layout with a preview tile on the right, placeholder when no URL, simplified Loop Video row.
- Introduced `<RemoteImage>` (per-image spinner overlay + fade-in + error icon) and applied it on the Posts list, Ayat/Hadith list, predesigned image selector, the ayat-hadith designer's `ImageTile`, and the YouTube preview.
- Slide reference + orientation helpers moved to `@/utils/ayat-hadith.ts`; both the list page and the designer import from there.

## Test plan
- [ ] Create a post → screen modal opens for the new post, with "Skip" button
- [ ] Cancel/Skip the modal → list shows the new row, no skeleton flash beforehand
- [ ] Save assignments in the modal → modal closes, list refetches, screen now shows the post
- [ ] Edit an existing post → no screen modal, list refetches as before
- [ ] Use the row "Screens" action → modal opens with "Cancel" label, no refetch on close
- [ ] Repeat for YouTube videos, announcements, events, and ayat/hadith (designer page navigates to list on modal close)
- [ ] Verify the fullscreen "PrayerBox" loader no longer flashes when the screen modal opens anywhere
- [ ] YouTube modal: open empty → see preview placeholder; paste URL → thumbnail loads with spinner
- [ ] Refresh Posts page on a slow connection → each thumbnail shows a spinner then fades in