### PR TITLE
feat(ayat-hadith-designer): keyword search for hadiths

### DIFF
--- a/src/api/hadith.ts
+++ b/src/api/hadith.ts
@@ -19,6 +19,46 @@ interface RawHadith {
   hadithUrdu: string;
   hadithArabic: string;
   englishNarrator: string;
+  bookSlug?: string;
+  status?: string;
+  book?: { bookName?: string };
+  chapter?: {
+    chapterNumber?: string;
+    chapterEnglish?: string;
+    chapterUrdu?: string;
+    chapterArabic?: string;
+  };
+}
+
+export interface HadithSearchResult {
+  id: string;
+  hadith_number: string;
+  book_slug: string;
+  book_name: string;
+  chapter_number: string;
+  chapter_english: string;
+  arabic: string;
+  urdu: string;
+  english: string;
+  narrator_english: string;
+  status: string;
+}
+
+export interface HadithSearchResponse {
+  results: HadithSearchResult[];
+  current_page: number;
+  last_page: number;
+  total: number;
+}
+
+export type HadithSearchLanguage = 'english' | 'urdu' | 'arabic';
+
+export interface HadithSearchParams {
+  query: string;
+  language?: HadithSearchLanguage;
+  bookSlug?: string;
+  page?: number;
+  paginate?: number;
 }
 
 function assertApiKey() {
@@ -57,6 +97,71 @@ export async function fetchHadith(
       source: 'hadith',
       operation: 'fetchHadith',
       extra: { bookSlug, hadithNumber },
+    });
+    throw error;
+  }
+}
+
+const SEARCH_PARAM_BY_LANGUAGE: Record<HadithSearchLanguage, string> = {
+  english: 'hadithEnglish',
+  urdu: 'hadithUrdu',
+  arabic: 'hadithArabic',
+};
+
+export async function searchHadith(
+  { query, language = 'english', bookSlug, page = 1, paginate = 25 }: HadithSearchParams,
+  signal?: AbortSignal
+): Promise<HadithSearchResponse> {
+  try {
+    assertApiKey();
+
+    const url = new URL(`${HADITH_BASE_URL}/hadiths`);
+    url.searchParams.set('apiKey', API_KEY);
+    url.searchParams.set(SEARCH_PARAM_BY_LANGUAGE[language], query);
+    url.searchParams.set('paginate', String(paginate));
+    url.searchParams.set('page', String(page));
+    if (bookSlug) url.searchParams.set('book', bookSlug);
+
+    const response = await fetch(url, { signal });
+
+    if (response.status === 404) {
+      return { results: [], current_page: page, last_page: 1, total: 0 };
+    }
+    if (!response.ok) throw new Error(`Failed to search hadiths: ${response.status}`);
+
+    const body = (await response.json()) as {
+      hadiths?: {
+        current_page?: number;
+        last_page?: number;
+        total?: number;
+        data?: RawHadith[];
+      };
+    };
+
+    const data = body.hadiths?.data ?? [];
+    return {
+      results: data.map(raw => ({
+        id: String(raw.id),
+        hadith_number: raw.hadithNumber,
+        book_slug: raw.bookSlug ?? '',
+        book_name: raw.book?.bookName ?? '',
+        chapter_number: raw.chapter?.chapterNumber ?? '',
+        chapter_english: raw.chapter?.chapterEnglish ?? '',
+        arabic: raw.hadithArabic ?? '',
+        urdu: raw.hadithUrdu ?? '',
+        english: raw.hadithEnglish ?? '',
+        narrator_english: raw.englishNarrator ?? '',
+        status: raw.status ?? '',
+      })),
+      current_page: body.hadiths?.current_page ?? page,
+      last_page: body.hadiths?.last_page ?? 1,
+      total: body.hadiths?.total ?? data.length,
+    };
+  } catch (error) {
+    captureExternalFetchError(error, {
+      source: 'hadith',
+      operation: 'searchHadith',
+      extra: { query, language, bookSlug, page },
     });
     throw error;
   }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,4 +10,12 @@ export { fetchWeatherForecast } from './openweather';
 
 export { fetchAyahWithEditions, type AyahResult } from './quran';
 
-export { fetchHadith, type HadithDetail } from './hadith';
+export {
+  fetchHadith,
+  searchHadith,
+  type HadithDetail,
+  type HadithSearchLanguage,
+  type HadithSearchParams,
+  type HadithSearchResponse,
+  type HadithSearchResult,
+} from './hadith';

--- a/src/components/ayat-hadith-designer/content-panel.tsx
+++ b/src/components/ayat-hadith-designer/content-panel.tsx
@@ -210,16 +210,18 @@ export function ContentPanel({
         </TabsContent>
 
         <TabsContent value='hadith' className='space-y-4 pt-4'>
-          <Button
+          <button
             type='button'
-            variant='outline'
-            size='sm'
-            className='w-full justify-start'
             onClick={() => setSearchOpen(true)}
+            className={cn(
+              'flex h-9 w-full items-center gap-2 rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors',
+              'text-muted-foreground hover:bg-accent hover:text-foreground',
+              'focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset'
+            )}
           >
-            <Search className='mr-2 h-4 w-4' />
-            Search hadiths by keyword…
-          </Button>
+            <Search className='h-4 w-4 shrink-0' />
+            <span className='flex-1 text-left'>Search hadiths by keyword…</span>
+          </button>
 
           <div className='grid grid-cols-[1fr_140px] gap-3'>
             <div className='space-y-2'>

--- a/src/components/ayat-hadith-designer/content-panel.tsx
+++ b/src/components/ayat-hadith-designer/content-panel.tsx
@@ -17,8 +17,9 @@ import {
 import { HADITH_BOOKS, QURAN_ARABIC_EDITION, QURAN_TRANSLATIONS, SURAHS } from '@/constants';
 import { fetchAyahWithEditions, fetchHadith } from '@/api';
 import type { AyatHadithCachedText, AyatHadithType } from '@/types';
-import { Check, Loader2 } from 'lucide-react';
+import { Check, Loader2, Search } from 'lucide-react';
 import { cn } from '@/utils';
+import { HadithSearchDialog } from './hadith-search-dialog';
 
 function buildAyatReference(surahNumber: number): { arabic: string; english: string } | undefined {
   const surah = SURAHS.find(s => s.number === surahNumber);
@@ -76,6 +77,7 @@ export function ContentPanel({
   const [fetching, setFetching] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [lastKey, setLastKey] = useState<string | null>(null);
+  const [searchOpen, setSearchOpen] = useState(false);
 
   useEffect(() => {
     const key = fingerprint(state);
@@ -208,6 +210,17 @@ export function ContentPanel({
         </TabsContent>
 
         <TabsContent value='hadith' className='space-y-4 pt-4'>
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            className='w-full justify-start'
+            onClick={() => setSearchOpen(true)}
+          >
+            <Search className='mr-2 h-4 w-4' />
+            Search hadiths by keyword…
+          </Button>
+
           <div className='grid grid-cols-[1fr_140px] gap-3'>
             <div className='space-y-2'>
               <Label>Book</Label>
@@ -393,6 +406,12 @@ export function ContentPanel({
         {fetching && <Loader2 className='mr-2 h-3 w-3 animate-spin' />}
         Refresh
       </Button>
+
+      <HadithSearchDialog
+        open={searchOpen}
+        onOpenChange={setSearchOpen}
+        onSelect={(book, hadith_number) => onChange({ ...state, book, hadith_number })}
+      />
     </div>
   );
 }

--- a/src/components/ayat-hadith-designer/hadith-search-dialog.tsx
+++ b/src/components/ayat-hadith-designer/hadith-search-dialog.tsx
@@ -11,6 +11,7 @@ import {
   Label,
   ScrollArea,
   Select,
+  Skeleton,
   SelectContent,
   SelectItem,
   SelectTrigger,
@@ -179,7 +180,7 @@ export function HadithSearchDialog({ open, onOpenChange, onSelect }: HadithSearc
         </form>
 
         <div className='border-t pt-3'>
-          {error && <p className='text-destructive text-sm mb-2'>{error}</p>}
+          {error && !loading && <p className='text-destructive text-sm mb-2'>{error}</p>}
 
           {!submittedQuery && !loading && !error && (
             <p className='text-muted-foreground text-sm text-center py-8'>
@@ -187,13 +188,37 @@ export function HadithSearchDialog({ open, onOpenChange, onSelect }: HadithSearc
             </p>
           )}
 
-          {submittedQuery && !loading && !error && results.length === 0 && (
+          {loading && (
+            <>
+              <div className='flex items-center justify-between mb-2'>
+                <Skeleton className='h-3 w-40' />
+                <Skeleton className='h-3 w-20' />
+              </div>
+              <div className='h-80 rounded-md border overflow-hidden'>
+                <ul className='divide-y'>
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <li key={i} className='p-3 space-y-2'>
+                      <div className='flex items-center gap-2'>
+                        <Skeleton className='h-4 w-32' />
+                        <Skeleton className='h-4 w-12 rounded-full' />
+                        <Skeleton className='h-3 w-24' />
+                      </div>
+                      <Skeleton className='h-3 w-full' />
+                      <Skeleton className='h-3 w-4/5' />
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </>
+          )}
+
+          {!loading && submittedQuery && !error && results.length === 0 && (
             <p className='text-muted-foreground text-sm text-center py-8'>
               No hadiths found for &ldquo;{submittedQuery}&rdquo;.
             </p>
           )}
 
-          {results.length > 0 && (
+          {!loading && results.length > 0 && (
             <>
               <div className='flex items-center justify-between text-xs text-muted-foreground mb-2'>
                 <span>

--- a/src/components/ayat-hadith-designer/hadith-search-dialog.tsx
+++ b/src/components/ayat-hadith-designer/hadith-search-dialog.tsx
@@ -1,0 +1,277 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Loader2, Search } from 'lucide-react';
+import {
+  Badge,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  ScrollArea,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui';
+import { HADITH_BOOKS } from '@/constants';
+import { searchHadith, type HadithSearchLanguage, type HadithSearchResult } from '@/api';
+import { cn } from '@/utils';
+
+interface HadithSearchDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (bookSlug: string, hadithNumber: string) => void;
+}
+
+const ANY_BOOK = '__any__';
+const PAGE_SIZE = 10;
+
+export function HadithSearchDialog({ open, onOpenChange, onSelect }: HadithSearchDialogProps) {
+  const [query, setQuery] = useState('');
+  const [language, setLanguage] = useState<HadithSearchLanguage>('english');
+  const [bookSlug, setBookSlug] = useState<string>(ANY_BOOK);
+  const [page, setPage] = useState(1);
+  const [submittedQuery, setSubmittedQuery] = useState('');
+
+  const [results, setResults] = useState<HadithSearchResult[]>([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [lastPage, setLastPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      abortRef.current?.abort();
+    }
+  }, [open]);
+
+  const runSearch = useCallback(
+    async (q: string, p: number) => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await searchHadith(
+          {
+            query: q,
+            language,
+            bookSlug: bookSlug === ANY_BOOK ? undefined : bookSlug,
+            page: p,
+            paginate: PAGE_SIZE,
+          },
+          controller.signal
+        );
+        setResults(res.results);
+        setCurrentPage(res.current_page);
+        setLastPage(res.last_page);
+        setTotal(res.total);
+      } catch (err) {
+        if ((err as Error).name === 'AbortError') return;
+        setError((err as Error).message);
+        setResults([]);
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    },
+    [language, bookSlug]
+  );
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = query.trim();
+    if (!trimmed) return;
+    setSubmittedQuery(trimmed);
+    setPage(1);
+    runSearch(trimmed, 1);
+  }
+
+  function goToPage(p: number) {
+    if (!submittedQuery || p < 1 || p > lastPage || p === currentPage) return;
+    setPage(p);
+    runSearch(submittedQuery, p);
+  }
+
+  function handlePick(r: HadithSearchResult) {
+    if (!r.book_slug || !r.hadith_number) return;
+    onSelect(r.book_slug, r.hadith_number);
+    onOpenChange(false);
+  }
+
+  function snippetFor(r: HadithSearchResult): string {
+    if (language === 'urdu') return r.urdu || r.english || r.arabic;
+    if (language === 'arabic') return r.arabic || r.english;
+    return r.english || r.urdu || r.arabic;
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='max-w-2xl'>
+        <DialogHeader>
+          <DialogTitle>Search hadiths</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className='space-y-3'>
+          <div className='grid grid-cols-[1fr_auto] gap-2'>
+            <div className='space-y-1'>
+              <Label htmlFor='hadith-search-query' className='text-xs'>
+                Keyword
+              </Label>
+              <Input
+                id='hadith-search-query'
+                value={query}
+                onChange={e => setQuery(e.target.value)}
+                placeholder='e.g. patience, prayer, intention'
+                autoFocus
+              />
+            </div>
+            <div className='flex items-end'>
+              <Button type='submit' disabled={loading || !query.trim()}>
+                {loading ? (
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                ) : (
+                  <Search className='h-4 w-4' />
+                )}
+                <span className='ml-2'>Search</span>
+              </Button>
+            </div>
+          </div>
+
+          <div className='grid grid-cols-2 gap-2'>
+            <div className='space-y-1'>
+              <Label className='text-xs'>Language</Label>
+              <Select value={language} onValueChange={v => setLanguage(v as HadithSearchLanguage)}>
+                <SelectTrigger className='w-full'>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value='english'>English</SelectItem>
+                  <SelectItem value='urdu'>Urdu</SelectItem>
+                  <SelectItem value='arabic'>Arabic</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className='space-y-1'>
+              <Label className='text-xs'>Book</Label>
+              <Select value={bookSlug} onValueChange={setBookSlug}>
+                <SelectTrigger className='w-full'>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ANY_BOOK}>Any book</SelectItem>
+                  {HADITH_BOOKS.map(b => (
+                    <SelectItem key={b.slug} value={b.slug}>
+                      {b.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </form>
+
+        <div className='border-t pt-3'>
+          {error && <p className='text-destructive text-sm mb-2'>{error}</p>}
+
+          {!submittedQuery && !loading && !error && (
+            <p className='text-muted-foreground text-sm text-center py-8'>
+              Enter a keyword and press Search to find hadiths.
+            </p>
+          )}
+
+          {submittedQuery && !loading && !error && results.length === 0 && (
+            <p className='text-muted-foreground text-sm text-center py-8'>
+              No hadiths found for &ldquo;{submittedQuery}&rdquo;.
+            </p>
+          )}
+
+          {results.length > 0 && (
+            <>
+              <div className='flex items-center justify-between text-xs text-muted-foreground mb-2'>
+                <span>
+                  {total.toLocaleString()} result{total === 1 ? '' : 's'} for &ldquo;
+                  {submittedQuery}&rdquo;
+                </span>
+                <span>
+                  Page {currentPage} of {lastPage}
+                </span>
+              </div>
+
+              <ScrollArea className='h-80 rounded-md border'>
+                <ul className='divide-y'>
+                  {results.map(r => (
+                    <li key={r.id}>
+                      <button
+                        type='button'
+                        onClick={() => handlePick(r)}
+                        className={cn(
+                          'w-full text-left p-3 hover:bg-accent transition',
+                          'focus:outline-none focus:bg-accent'
+                        )}
+                      >
+                        <div className='flex items-center gap-2 mb-1 flex-wrap'>
+                          <span className='font-medium text-sm'>
+                            {r.book_name || r.book_slug} #{r.hadith_number}
+                          </span>
+                          {r.status && (
+                            <Badge variant='secondary' className='text-[10px]'>
+                              {r.status}
+                            </Badge>
+                          )}
+                          {r.chapter_english && (
+                            <span className='text-xs text-muted-foreground'>
+                              · {r.chapter_english}
+                            </span>
+                          )}
+                        </div>
+                        <p
+                          className={cn(
+                            'text-xs text-muted-foreground line-clamp-2',
+                            language === 'arabic' && 'text-right',
+                            language === 'urdu' && 'text-right'
+                          )}
+                          dir={language === 'english' ? 'ltr' : 'rtl'}
+                        >
+                          {snippetFor(r)}
+                        </p>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </ScrollArea>
+
+              <div className='flex items-center justify-between mt-3'>
+                <Button
+                  type='button'
+                  variant='outline'
+                  size='sm'
+                  disabled={loading || currentPage <= 1}
+                  onClick={() => goToPage(page - 1)}
+                >
+                  Previous
+                </Button>
+                <Button
+                  type='button'
+                  variant='outline'
+                  size='sm'
+                  disabled={loading || currentPage >= lastPage}
+                  onClick={() => goToPage(page + 1)}
+                >
+                  Next
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `searchHadith()` in `src/api/hadith.ts` wrapping hadithapi.com's keyword filters (English/Urdu/Arabic), with optional book filter and pagination
- Adds a `HadithSearchDialog` opened from a "Search hadiths by keyword…" button on the Hadith tab of the ayat-hadith designer; picking a result fills `book` + `hadith_number` and the existing fetch effect loads the content
- Treats HTTP 404 from the search endpoint as an empty result set (the API returns 404 with `Hadiths not found.` when nothing matches), so users see an empty-state message instead of a red error

## Test plan
- [ ] Open the ayat-hadith designer → switch to the Hadith tab → click "Search hadiths by keyword…"
- [ ] Search for an English keyword (e.g. "patience") with "Any book" and verify multiple results across books
- [ ] Filter by a specific book and re-search — results should be limited to that book
- [ ] Switch language to Urdu/Arabic, search in that script, verify RTL snippets render correctly
- [ ] Paginate Next/Previous and verify state stays consistent
- [ ] Search for a nonsense string and verify the empty-state message appears (no red error)
- [ ] Pick a result and verify the canvas loads the chosen hadith