### PR TITLE
feat(legal): add public privacy policy and terms pages

### DIFF
--- a/src/components/common/auth-legal-links.tsx
+++ b/src/components/common/auth-legal-links.tsx
@@ -1,0 +1,24 @@
+import { Link } from 'react-router';
+import { PublicRoutes } from '@/constants';
+
+export function AuthLegalLinks() {
+  return (
+    <div className='text-center text-xs text-muted-foreground'>
+      By continuing, you agree to our{' '}
+      <Link
+        to={PublicRoutes.TermsConditions}
+        className='underline underline-offset-2 hover:text-primary'
+      >
+        Terms
+      </Link>{' '}
+      and{' '}
+      <Link
+        to={PublicRoutes.PrivacyPolicy}
+        className='underline underline-offset-2 hover:text-primary'
+      >
+        Privacy Policy
+      </Link>
+      .
+    </div>
+  );
+}

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -4,3 +4,4 @@ export * from './empty-state';
 export * from './action-buttons';
 export * from './data-table';
 export * from './orientation-badge';
+export * from './auth-legal-links';

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -5,6 +5,11 @@ export enum AuthRoutes {
   ForgotPassword = '/forgot-password',
 }
 
+export enum PublicRoutes {
+  PrivacyPolicy = '/privacy',
+  TermsConditions = '/terms',
+}
+
 export enum AppRoutes {
   Display = '/',
   DisplayLogout = '/logout',

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState, Suspense } from 'react';
 import { getCurrentSession, getMasjidMembership, updateLastActive } from '@/lib/supabase';
 import { subscribeToAuthChanges } from '@/lib/supabase';
 import { identifySentryUser, clearSentryUser } from '@/lib/sentry';
-import { AppRoutes, AuthRoutes } from '@/constants';
+import { AppRoutes, AuthRoutes, PublicRoutes } from '@/constants';
 import { AppLayout } from '@/components/layout';
 import {
   Announcements,
@@ -29,6 +29,8 @@ import {
   LoginWithCode,
   YouTubeVideos,
   Support,
+  PrivacyPolicy,
+  TermsConditions,
 } from '@/pages';
 import { useDisplayStore, useAuthStore } from '@/store';
 
@@ -108,6 +110,10 @@ export default function Navigation() {
     <BrowserRouter>
       <Suspense fallback={<Loading />}>
         <Routes>
+          {/* Public legal routes - accessible without authentication */}
+          <Route path={PublicRoutes.PrivacyPolicy} element={<PrivacyPolicy />} />
+          <Route path={PublicRoutes.TermsConditions} element={<TermsConditions />} />
+
           {/* Email auth routes - only accessible when not logged in with email */}
           <Route element={isLoggedInWithEmail ? <Navigate to={AppRoutes.Home} /> : <Outlet />}>
             <Route path={AuthRoutes.Login} element={<Login />} />

--- a/src/pages/auth/forgot-password.tsx
+++ b/src/pages/auth/forgot-password.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, Input, Label, ErrorBox } from '@/components/ui';
+import { AuthLegalLinks } from '@/components/common';
 import { cn } from '@/utils';
 import { forgotPasswordSchema, type ForgotPasswordData } from '@/lib/zod';
 import { Link } from 'react-router';
@@ -90,6 +91,7 @@ export default function ForgotPassword() {
               Sign in
             </Link>
           </div>
+          <AuthLegalLinks />
         </div>
       </div>
     </div>

--- a/src/pages/auth/login-with-code.tsx
+++ b/src/pages/auth/login-with-code.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, Input, Label, ErrorBox } from '@/components/ui';
+import { AuthLegalLinks } from '@/components/common';
 import { cn } from '@/utils';
 import { loginWithCodeSchema, type LoginWithCodeData } from '@/lib/zod';
 import { Link, useSearchParams } from 'react-router';
@@ -102,6 +103,7 @@ export default function LoginWithCode() {
               </Button>
             </div>
           </form>
+          <AuthLegalLinks />
         </div>
       </div>
     </div>

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, Input, Label, ErrorBox } from '@/components/ui';
+import { AuthLegalLinks } from '@/components/common';
 import { cn } from '@/utils';
 import { Eye, EyeOff } from 'lucide-react';
 import { loginFormSchema, type LoginFormData } from '@/lib/zod';
@@ -123,6 +124,7 @@ export default function Login() {
               Create an account
             </Link>
           </div>
+          <AuthLegalLinks />
         </div>
       </div>
     </div>

--- a/src/pages/auth/register.tsx
+++ b/src/pages/auth/register.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, Input, Label, ErrorBox, PasswordStrengthMeter } from '@/components/ui';
+import { AuthLegalLinks } from '@/components/common';
 import { cn } from '@/utils';
 import { Eye, EyeOff } from 'lucide-react';
 import { registerFormSchema, type RegisterFormData } from '@/lib/zod';
@@ -140,6 +141,7 @@ export default function Register() {
               Sign in
             </Link>
           </div>
+          <AuthLegalLinks />
         </div>
       </div>
     </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,3 +3,4 @@
 export { default as Loading } from './loading-page';
 export * from './auth';
 export * from './app';
+export * from './legal';

--- a/src/pages/legal/index.ts
+++ b/src/pages/legal/index.ts
@@ -1,0 +1,4 @@
+import { lazy } from 'react';
+
+export const PrivacyPolicy = lazy(() => import('./privacy-policy'));
+export const TermsConditions = lazy(() => import('./terms-conditions'));

--- a/src/pages/legal/legal-layout.tsx
+++ b/src/pages/legal/legal-layout.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from 'react';
+import { Link, useNavigate } from 'react-router';
+import { ArrowLeft } from 'lucide-react';
+import { PublicRoutes, AuthRoutes } from '@/constants';
+import { Button } from '@/components/ui';
+
+type LegalLayoutProps = {
+  title: string;
+  lastUpdated: string;
+  children: ReactNode;
+};
+
+export function LegalLayout({ title, lastUpdated, children }: LegalLayoutProps) {
+  const navigate = useNavigate();
+
+  const handleBack = () => {
+    if (window.history.length > 1) {
+      navigate(-1);
+    } else {
+      navigate(AuthRoutes.Login);
+    }
+  };
+
+  return (
+    <div className='min-h-screen bg-background'>
+      <header className='sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80'>
+        <div className='mx-auto flex max-w-5xl items-center gap-3 px-4 py-3 sm:px-6'>
+          <Button
+            variant='ghost'
+            size='icon'
+            onClick={handleBack}
+            aria-label='Go back'
+            className='h-8 w-8'
+          >
+            <ArrowLeft size={18} />
+          </Button>
+          <Link to={AuthRoutes.Login} className='flex items-center gap-2'>
+            <div className='flex h-7 w-7 items-center justify-center rounded-md bg-emerald-500 text-white'>
+              <span className='text-sm font-bold'>P</span>
+            </div>
+            <span className='text-base font-semibold'>PrayerBox</span>
+          </Link>
+        </div>
+      </header>
+
+      <main className='mx-auto max-w-5xl px-4 py-8 sm:px-6 sm:py-12'>
+        <div className='mb-8 space-y-2'>
+          <h1 className='text-2xl font-bold tracking-tight sm:text-3xl'>{title}</h1>
+          <p className='text-sm text-muted-foreground'>Last updated: {lastUpdated}</p>
+        </div>
+
+        <article
+          className='space-y-6 text-sm leading-relaxed text-foreground/90
+            [&_h2]:mt-8 [&_h2]:scroll-mt-24 [&_h2]:text-lg [&_h2]:font-semibold [&_h2]:text-foreground
+            [&_h3]:mt-6 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:text-foreground
+            [&_p]:my-3
+            [&_ul]:my-3 [&_ul]:list-disc [&_ul]:pl-6 [&_ul]:space-y-1
+            [&_ol]:my-3 [&_ol]:list-decimal [&_ol]:pl-6 [&_ol]:space-y-1
+            [&_a]:text-emerald-600 [&_a]:underline [&_a]:underline-offset-2 hover:[&_a]:text-emerald-700
+            [&_strong]:font-semibold [&_strong]:text-foreground'
+        >
+          {children}
+        </article>
+
+        <footer className='mt-12 flex flex-col items-center justify-between gap-3 border-t pt-6 text-sm text-muted-foreground sm:flex-row'>
+          <div className='flex items-center gap-4'>
+            <Link
+              to={PublicRoutes.PrivacyPolicy}
+              className='hover:text-foreground hover:underline underline-offset-4'
+            >
+              Privacy Policy
+            </Link>
+            <Link
+              to={PublicRoutes.TermsConditions}
+              className='hover:text-foreground hover:underline underline-offset-4'
+            >
+              Terms &amp; Conditions
+            </Link>
+          </div>
+          <span>&copy; {new Date().getFullYear()} PrayerBox</span>
+        </footer>
+      </main>
+    </div>
+  );
+}

--- a/src/pages/legal/privacy-policy.tsx
+++ b/src/pages/legal/privacy-policy.tsx
@@ -1,0 +1,272 @@
+import { LegalLayout } from './legal-layout';
+
+export default function PrivacyPolicy() {
+  return (
+    <LegalLayout title='Privacy Policy' lastUpdated='25 November 2025'>
+      <p>
+        This Privacy Policy explains how <strong>PrayerBox</strong> ("we", "us", "our") collects,
+        uses, and protects information about administrators, moderators, display operators, and
+        visitors ("you") when you use the PrayerBox application and related services (the
+        "Services").
+      </p>
+      <p>By using the Services, you consent to the practices described in this Privacy Policy.</p>
+
+      <h2>1. Who We Are</h2>
+      <p>
+        PrayerBox is a software-as-a-service platform that helps masjids manage prayer timings,
+        announcements, posts, events, Quranic ayat and hadith content, and the digital displays
+        shown inside their facilities.
+      </p>
+      <p>
+        If you have questions about this Privacy Policy or your data, you can contact us through the
+        in-app Support page or by email at <strong>[Contact Email]</strong>.
+      </p>
+
+      <h2>2. Information We Collect</h2>
+
+      <h3>2.1 Information You Provide Directly</h3>
+      <ul>
+        <li>
+          <strong>Account information:</strong> Email address and password used to sign in,
+          masjid/organisation name, role (admin or moderator), and contact details you choose to
+          add.
+        </li>
+        <li>
+          <strong>Masjid profile:</strong> Masjid name, address, geographic coordinates, prayer
+          calculation preferences, jamaat times, logo, and other configuration you provide.
+        </li>
+        <li>
+          <strong>Content you upload:</strong> Announcements, posts, event details, ayat/hadith
+          slide designs, images, YouTube video links, and any other content you publish to your
+          displays.
+        </li>
+        <li>
+          <strong>Display registration:</strong> Screen names, orientation, location labels, and the
+          screen codes generated to pair physical displays with your account.
+        </li>
+        <li>
+          <strong>Communications:</strong> Messages or feedback you send through the Support form or
+          by email.
+        </li>
+      </ul>
+
+      <h3>2.2 Information Collected Automatically</h3>
+      <ul>
+        <li>
+          <strong>Log and device data:</strong> IP address, browser type, device information, the
+          pages you visit within the app, and timestamps of significant actions (for example,
+          last-active time on your account).
+        </li>
+        <li>
+          <strong>Error and performance data:</strong> When something goes wrong, our error
+          monitoring provider records details about the error (such as a stack trace, browser
+          information, and the user identifier associated with the session) so we can diagnose and
+          fix the issue.
+        </li>
+        <li>
+          <strong>Cookies and local storage:</strong> Small data files stored on your device to keep
+          you signed in, remember preferences (such as theme and sidebar state), and keep a paired
+          display screen authenticated between visits.
+        </li>
+      </ul>
+
+      <h2>3. How We Use Your Information</h2>
+      <ul>
+        <li>
+          <strong>To provide the Services</strong> — authenticate you, sync your masjid
+          configuration, render your displays, and deliver the content you publish.
+        </li>
+        <li>
+          <strong>To maintain account security</strong> — detect suspicious activity, recover
+          accounts, and protect against abuse.
+        </li>
+        <li>
+          <strong>To respond to your inquiries</strong> sent through Support, email, or other
+          channels.
+        </li>
+        <li>
+          <strong>To improve the Services</strong> — diagnose bugs, monitor performance, and
+          understand which features are useful.
+        </li>
+        <li>
+          <strong>To send service-related communications</strong> — for example, password resets,
+          security notices, or notices about material changes to the Services.
+        </li>
+        <li>
+          <strong>To comply with legal obligations</strong> and enforce our Terms &amp; Conditions.
+        </li>
+      </ul>
+
+      <h2>4. Legal Bases for Processing</h2>
+      <p>
+        Depending on your jurisdiction, we may rely on different legal bases to process your
+        personal data:
+      </p>
+      <ul>
+        <li>
+          The <strong>performance of a contract</strong> (providing the Services you signed up for).
+        </li>
+        <li>
+          Your <strong>consent</strong>, where required (for example, optional communications).
+        </li>
+        <li>
+          Our <strong>legitimate interests</strong> in operating, securing, and improving the
+          Services.
+        </li>
+        <li>
+          <strong>Compliance with legal obligations</strong>, such as tax, accounting, or
+          law-enforcement requirements.
+        </li>
+      </ul>
+
+      <h2>5. How We Share Your Information</h2>
+      <p>We do not sell your personal information.</p>
+      <p>We share information with:</p>
+      <ul>
+        <li>
+          <strong>Infrastructure and service providers</strong> who help us operate the Services,
+          including our database, authentication and file storage provider (Supabase), error and
+          performance monitoring (Sentry), and our email/transactional message providers.
+        </li>
+        <li>
+          <strong>Third-party content sources</strong> we integrate with, such as Quran and hadith
+          data providers, prayer-time calculation libraries, and YouTube (when you embed videos).
+          These services have their own privacy policies governing the data they receive.
+        </li>
+        <li>
+          <strong>Professional advisers</strong> (for example, legal or accounting advisers) where
+          necessary.
+        </li>
+        <li>
+          <strong>Authorities or law enforcement</strong> where required by law, court order, or to
+          protect our rights or users.
+        </li>
+      </ul>
+
+      <h2>6. Content You Publish</h2>
+      <p>
+        Content you publish through PrayerBox (announcements, posts, events, ayat/hadith designs) is
+        displayed inside your masjid's facilities through your registered screens. You are
+        responsible for the accuracy, legality, and appropriateness of that content. Where the
+        Services allow you to add moderators, the masjid administrator remains responsible for
+        oversight of moderator activity.
+      </p>
+
+      <h2>7. Cookies and Similar Technologies</h2>
+      <p>We use:</p>
+      <ul>
+        <li>
+          <strong>Essential cookies and local storage</strong> required for the Services to function
+          — for example, keeping you signed in and keeping a paired display screen authenticated.
+        </li>
+        <li>
+          <strong>Preference storage</strong> for choices such as light/dark theme and sidebar
+          state.
+        </li>
+        <li>
+          <strong>Diagnostic data</strong> used by our error and performance monitoring tools.
+        </li>
+      </ul>
+      <p>
+        You can clear or block this storage through your browser settings, but doing so may sign you
+        out and reset your preferences.
+      </p>
+
+      <h2>8. Data Retention</h2>
+      <p>We retain your personal information for as long as necessary to:</p>
+      <ul>
+        <li>Provide the Services to you;</li>
+        <li>Comply with legal, tax, and accounting requirements;</li>
+        <li>Resolve disputes and enforce our agreements.</li>
+      </ul>
+      <p>
+        When you delete your account or specific content, we will take reasonable steps to remove or
+        anonymise the associated personal data, except where retention is required by law.
+      </p>
+
+      <h2>9. Data Security</h2>
+      <p>
+        We take reasonable technical and organisational measures — including encrypted transport,
+        access controls, and managed authentication — to protect your information against
+        unauthorised access, loss, misuse, or alteration. However, no method of transmission over
+        the internet or electronic storage is completely secure, and we cannot guarantee absolute
+        security.
+      </p>
+
+      <h2>10. International Data Transfers</h2>
+      <p>
+        Our infrastructure providers may process your data in data centres located outside your
+        country of residence. Where required by law, we rely on appropriate safeguards (such as
+        standard contractual clauses) for such transfers. By using the Services, you consent to
+        these transfers subject to applicable law.
+      </p>
+
+      <h2>11. Your Rights</h2>
+      <p>
+        Depending on your jurisdiction, you may have some or all of the following rights regarding
+        your personal data:
+      </p>
+      <ul>
+        <li>
+          <strong>Access</strong> — request a copy of the personal data we hold about you.
+        </li>
+        <li>
+          <strong>Rectification</strong> — request correction of inaccurate or incomplete data.
+        </li>
+        <li>
+          <strong>Deletion</strong> — request deletion of your data, subject to legal exceptions.
+        </li>
+        <li>
+          <strong>Restriction</strong> — limit how we use your data in certain cases.
+        </li>
+        <li>
+          <strong>Objection</strong> — object to certain processing, including direct marketing.
+        </li>
+        <li>
+          <strong>Withdraw consent</strong> at any time where processing is based on your consent.
+        </li>
+      </ul>
+      <p>
+        To exercise these rights, contact us through the Support page or at{' '}
+        <strong>[Contact Email]</strong>. We may need to verify your identity before fulfilling your
+        request.
+      </p>
+
+      <h2>12. Children's Privacy</h2>
+      <p>
+        PrayerBox is intended for use by masjid administrators and the moderators they appoint. We
+        do not knowingly collect personal information from children. If you believe a child has
+        provided us with personal data, please contact us and we will take appropriate action.
+      </p>
+
+      <h2>13. Third-Party Links and Embedded Content</h2>
+      <p>
+        The Services may link to or embed content from third-party sites (for example, YouTube
+        videos you choose to display). We are not responsible for the privacy practices or content
+        of those third parties. We encourage you to review their privacy policies.
+      </p>
+
+      <h2>14. Changes to This Privacy Policy</h2>
+      <p>
+        We may update this Privacy Policy from time to time. When we do, we will update the "Last
+        updated" date at the top of this page. For material changes, we will take reasonable steps
+        to notify you. Your continued use of the Services after changes are posted constitutes
+        acceptance of the updated policy.
+      </p>
+
+      <h2>15. Contact Us</h2>
+      <p>
+        If you have any questions, concerns, or requests regarding this Privacy Policy or our
+        handling of your personal information, please contact us:
+      </p>
+      <ul>
+        <li>
+          <strong>Email:</strong> [Contact Email]
+        </li>
+        <li>
+          <strong>Support:</strong> Through the Support page in your PrayerBox account.
+        </li>
+      </ul>
+    </LegalLayout>
+  );
+}

--- a/src/pages/legal/terms-conditions.tsx
+++ b/src/pages/legal/terms-conditions.tsx
@@ -1,0 +1,244 @@
+import { LegalLayout } from './legal-layout';
+
+export default function TermsConditions() {
+  return (
+    <LegalLayout title='Terms & Conditions' lastUpdated='25 November 2025'>
+      <p>
+        Welcome to <strong>PrayerBox</strong> ("we", "us", "our"). These Terms &amp; Conditions
+        ("Terms") govern your access to and use of the PrayerBox application and related services
+        (the "Services").
+      </p>
+      <p>
+        By accessing or using the Services, you agree to be bound by these Terms. If you do not
+        agree, please do not use the Services.
+      </p>
+
+      <h2>1. Definitions</h2>
+      <ul>
+        <li>
+          <strong>"Services"</strong> — the PrayerBox web application, display screens, APIs, and
+          related features.
+        </li>
+        <li>
+          <strong>"User", "you"</strong> — any person accessing or using the Services, including
+          administrators, moderators, and display operators.
+        </li>
+        <li>
+          <strong>"Account"</strong> — the credentials and configuration associated with a masjid on
+          PrayerBox.
+        </li>
+        <li>
+          <strong>"Content"</strong> — text, images, audio, video, links, designs, and other
+          material made available through the Services, including User Content you upload.
+        </li>
+      </ul>
+
+      <h2>2. Acceptance of Terms</h2>
+      <p>
+        By accessing or using the Services, you acknowledge that you have read and understood these
+        Terms and agree to be legally bound by them. If you are using the Services on behalf of a
+        masjid or other organisation, you represent that you have the authority to bind that
+        organisation to these Terms.
+      </p>
+
+      <h2>3. Eligibility</h2>
+      <p>
+        You may use the Services only if you are at least the age of majority in your jurisdiction
+        and capable of entering into a binding contract. The Services are intended for use by masjid
+        administrators and the moderators they appoint.
+      </p>
+
+      <h2>4. Accounts</h2>
+      <p>To use most features of the Services you must create an account. When you do so:</p>
+      <ul>
+        <li>You must provide accurate, current, and complete information.</li>
+        <li>You are responsible for maintaining the confidentiality of your credentials.</li>
+        <li>
+          You are responsible for all activity that occurs under your account, including the actions
+          of moderators you invite.
+        </li>
+        <li>You must notify us immediately of any unauthorised use of your account.</li>
+      </ul>
+      <p>
+        We may suspend or terminate accounts that violate these Terms or that we reasonably believe
+        pose a risk to other users or to the Services.
+      </p>
+
+      <h2>5. Display Screen Codes</h2>
+      <p>
+        The Services allow you to pair physical or virtual display screens with your account using a
+        screen code. You are responsible for keeping these codes private. Anyone with a valid screen
+        code can render the public-facing content you have published to that screen. We are not
+        responsible for content shown on screens connected through codes that have been shared
+        outside your masjid.
+      </p>
+
+      <h2>6. Acceptable Use</h2>
+      <p>You agree to use the Services only for lawful purposes and not to:</p>
+      <ul>
+        <li>Violate any applicable laws, regulations, or third-party rights;</li>
+        <li>
+          Upload or display Content that is unlawful, defamatory, hateful, obscene, or otherwise
+          objectionable;
+        </li>
+        <li>
+          Impersonate any person or misrepresent your affiliation with any masjid or organisation;
+        </li>
+        <li>
+          Attempt to gain unauthorised access to the Services, other users' accounts, or any system
+          or network connected to the Services;
+        </li>
+        <li>
+          Interfere with, disrupt, or place an unreasonable load on the Services or the underlying
+          infrastructure;
+        </li>
+        <li>Reverse engineer, decompile, or attempt to extract the source code of the Services;</li>
+        <li>
+          Use the Services to send unsolicited communications or to violate any individual's
+          privacy.
+        </li>
+      </ul>
+
+      <h2>7. Your Content</h2>
+      <p>
+        You retain ownership of the Content you upload to the Services ("User Content"). By
+        uploading User Content, you grant us a worldwide, non-exclusive, royalty-free licence to
+        host, store, reproduce, display, and transmit that User Content solely as needed to operate
+        the Services on your behalf — for example, to render it on your screens, sync it between
+        devices, or back it up.
+      </p>
+      <p>You represent and warrant that:</p>
+      <ul>
+        <li>You own your User Content or have all necessary rights to upload and display it;</li>
+        <li>
+          Your User Content does not infringe any third-party intellectual property, privacy, or
+          other rights;
+        </li>
+        <li>Your User Content complies with applicable laws and these Terms.</li>
+      </ul>
+      <p>
+        We may remove User Content that, in our reasonable judgement, violates these Terms or
+        applicable law.
+      </p>
+
+      <h2>8. Third-Party Content and Services</h2>
+      <p>
+        The Services include Content and integrations provided by third parties — for example,
+        Quranic verses, hadith collections, prayer-time calculations, YouTube video embeds, and map
+        data. Such Content is provided for your convenience and may be subject to the terms and
+        licences of the original provider. We do not warrant the accuracy, completeness, or
+        suitability of third-party Content for any particular purpose.
+      </p>
+
+      <h2>9. Religious and Educational Content</h2>
+      <p>
+        Religious, educational, and spiritual Content available through the Services is provided for
+        general guidance and reminder. It does not replace personal, tailored religious counsel from
+        qualified scholars. You are responsible for reviewing the Content you publish through your
+        displays and for ensuring it reflects the values and policies of your masjid.
+      </p>
+
+      <h2>10. Intellectual Property</h2>
+      <p>
+        All rights, title, and interest in and to the Services — including the software, design,
+        trademarks, and original Content — are owned by us or our licensors and are protected by
+        applicable intellectual property laws. Except for the limited rights expressly granted in
+        these Terms, no rights are granted to you.
+      </p>
+      <p>
+        You may not reproduce, distribute, modify, create derivative works of, publicly display, or
+        commercially exploit any part of the Services without our prior written consent.
+      </p>
+
+      <h2>11. Feedback</h2>
+      <p>
+        If you provide us with suggestions, ideas, or feedback about the Services, you grant us a
+        non-exclusive, royalty-free, perpetual, irrevocable, worldwide licence to use that feedback
+        for any purpose, without compensation or attribution.
+      </p>
+
+      <h2>12. Service Availability and Modifications</h2>
+      <p>
+        We strive to keep the Services available and functioning correctly, but we do not guarantee
+        uninterrupted or error-free operation. We may modify, suspend, or discontinue any part of
+        the Services at any time, with or without notice. We are not liable to you or any third
+        party for any modification, suspension, or discontinuation of the Services.
+      </p>
+
+      <h2>13. Disclaimers</h2>
+      <p>
+        The Services and all Content are provided on an <strong>"as is"</strong> and{' '}
+        <strong>"as available"</strong> basis. To the fullest extent permitted by law, we disclaim
+        all warranties of any kind, whether express or implied, including warranties of
+        merchantability, fitness for a particular purpose, non-infringement, and warranties as to
+        the accuracy or reliability of any Content (including prayer times and religious material).
+      </p>
+
+      <h2>14. Limitation of Liability</h2>
+      <p>To the fullest extent permitted by applicable law:</p>
+      <ul>
+        <li>
+          We shall not be liable for any indirect, incidental, special, consequential, or punitive
+          damages, or any loss of profits, revenues, data, or goodwill arising out of or related to
+          your use of the Services.
+        </li>
+        <li>
+          Our total aggregate liability for any claims arising out of or related to the Services or
+          these Terms shall not exceed the greater of (a) the amount you paid us for the Services in
+          the twelve months preceding the event giving rise to the claim, or (b) one hundred U.S.
+          dollars (US$100).
+        </li>
+      </ul>
+      <p>
+        Some jurisdictions do not allow certain limitations of liability; in those jurisdictions the
+        above limitations apply only to the extent permitted by law.
+      </p>
+
+      <h2>15. Indemnity</h2>
+      <p>
+        You agree to indemnify, defend, and hold harmless PrayerBox, our affiliates, and our
+        respective officers, employees, and agents from and against any claims, liabilities,
+        damages, losses, and expenses (including reasonable legal fees) arising out of or in any way
+        connected with:
+      </p>
+      <ul>
+        <li>Your use of the Services;</li>
+        <li>Your User Content;</li>
+        <li>Your violation of these Terms;</li>
+        <li>Your violation of any rights of another person or entity.</li>
+      </ul>
+
+      <h2>16. Termination</h2>
+      <p>
+        You may stop using the Services at any time. We may suspend or terminate your access to the
+        Services at any time, with or without notice, if we reasonably believe you have violated
+        these Terms or if we are required to do so by law. Upon termination, the sections of these
+        Terms that by their nature should survive (including intellectual property, disclaimers,
+        limitation of liability, indemnity, and governing law) will continue to apply.
+      </p>
+
+      <h2>17. Governing Law and Dispute Resolution</h2>
+      <p>
+        These Terms and any dispute arising out of or relating to the Services shall be governed by
+        and construed in accordance with the laws of <strong>[Jurisdiction]</strong>, without regard
+        to its conflict-of-law principles. The parties agree to the exclusive jurisdiction of the
+        courts located in <strong>[Venue]</strong>, except where mandatory local law provides
+        otherwise.
+      </p>
+
+      <h2>18. Changes to These Terms</h2>
+      <p>
+        We may update these Terms from time to time. When we do, we will revise the "Last updated"
+        date at the top of this page. For material changes, we will take reasonable steps to notify
+        you. Your continued use of the Services after such changes constitutes acceptance of the
+        updated Terms.
+      </p>
+
+      <h2>19. Contact Us</h2>
+      <p>
+        If you have any questions about these Terms, please contact us through the in-app Support
+        page or by email at <strong>[Contact Email]</strong>.
+      </p>
+    </LegalLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds public `/privacy` and `/terms` routes (no auth) under a new `PublicRoutes` enum, served via a shared `LegalLayout`
- Surfaces a small `AuthLegalLinks` footer on Login, Register, Forgot Password, and Login With Code so users can reach the legal pages from auth flows
- Content was adapted from the source template (shaykhrahmatalamjan.com) into a SaaS-shaped policy for PrayerBox — e-commerce sections replaced with account, screen-code, user-content, and sub-processor wording

## Before merge / before launch
The copy still contains intentional placeholders that need to be filled in by someone with the relevant info:
- `[Contact Email]` — Privacy §1, §11, §15; Terms §19
- `[Jurisdiction]` and `[Venue]` — Terms §17 (governing law)
- Recommend a quick review by legal counsel before this is publicly linked

## Test plan
- [ ] Visit `/privacy` and `/terms` while logged out — pages render, footer cross-links work
- [ ] Visit them while logged in as admin and as a paired display — no redirect interception
- [ ] On Login, Register, Forgot Password, and Login With Code, the new footer link opens the correct page
- [ ] Back button in the legal page header returns to the previous route (falls back to `/login` when there's no history)
- [ ] Container width feels right on desktop and mobile (uses `max-w-5xl`)
- [ ] `npm run lint` and `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)