### PR TITLE
Auto-resize image uploads instead of rejecting oversized ones

### DIFF
--- a/src/components/common/background-upload-tile.tsx
+++ b/src/components/common/background-upload-tile.tsx
@@ -2,9 +2,9 @@ import { useId, useRef, useState } from 'react';
 import { Loader2, Upload } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '@/utils';
-import { validateImageForFullScreen } from '@/utils';
+import { validateImageForFullScreen, downscaleImageToCover } from '@/utils';
 import { uploadBackgroundImage } from '@/lib/supabase';
-import { MAX_FILE_SIZE, VALID_IMAGE_TYPES } from '@/lib/zod';
+import { VALID_IMAGE_TYPES } from '@/lib/zod';
 import type { PostOrientation } from '@/types';
 
 interface BackgroundUploadTileProps {
@@ -17,9 +17,10 @@ interface BackgroundUploadTileProps {
 
 /**
  * Reusable "upload a background" tile: a dashed drop-target button with a hidden
- * file input. Validates the file (type, size, dimensions) using the existing
- * full-screen image validators — no client-side resizing — then uploads it to
- * the per-masjid `user-backgrounds` folder and hands the URL back to the caller.
+ * file input. Validates the file's type and aspect ratio using the full-screen
+ * image validators, downscales oversized images to fit the display bounds, then
+ * uploads to the per-masjid `user-backgrounds` folder and hands the URL back to
+ * the caller.
  *
  * Shared so the Ayat/Hadith builder can reuse the same upload affordance.
  */
@@ -37,11 +38,6 @@ export function BackgroundUploadTile({
       toast.error('Unsupported file type. Use JPEG, PNG, GIF, or WebP.');
       return;
     }
-    if (file.size > MAX_FILE_SIZE) {
-      const maxMb = Math.round(MAX_FILE_SIZE / (1024 * 1024));
-      toast.error(`Image is larger than ${maxMb}MB. Please use a smaller file.`);
-      return;
-    }
 
     const validation = await validateImageForFullScreen(file, orientation);
     if (!validation.isValid) {
@@ -51,7 +47,8 @@ export function BackgroundUploadTile({
 
     setUploading(true);
     try {
-      const url = await uploadBackgroundImage(file);
+      const optimized = await downscaleImageToCover(file, orientation);
+      const url = await uploadBackgroundImage(optimized);
       onUploaded(url);
       toast.success('Image uploaded');
     } catch (error) {

--- a/src/components/modals/post-modal/image-requirements.tsx
+++ b/src/components/modals/post-modal/image-requirements.tsx
@@ -15,9 +15,10 @@ type ImageRequirementsProps = {
 };
 
 /**
- * Compact panel that spells out every upload restriction (ratio, formats,
- * file size, and the min/max/recommended resolutions) so users see the full
- * rules up front instead of discovering them through rejection errors.
+ * Compact panel that spells out the upload rules (ratio, formats, and how
+ * file size / resolution are handled) so users see the requirements up front.
+ * The aspect ratio is the only hard gate — oversized images are downscaled
+ * automatically rather than rejected.
  */
 export function ImageRequirements({ orientation }: ImageRequirementsProps) {
   const requirements = getImageRequirements(orientation);
@@ -49,15 +50,7 @@ export function ImageRequirements({ orientation }: ImageRequirementsProps) {
       </ul>
 
       <p className='mt-3 border-t pt-3 text-[11px] text-muted-foreground'>
-        Need to resize your image? Try{' '}
-        <a
-          href='https://imageresizer.com/'
-          target='_blank'
-          rel='noopener noreferrer'
-          className='text-primary hover:underline'
-        >
-          imageresizer.com
-        </a>
+        Large images are resized automatically — just make sure the aspect ratio matches.
       </p>
     </div>
   );

--- a/src/components/modals/post-modal/index.tsx
+++ b/src/components/modals/post-modal/index.tsx
@@ -3,6 +3,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { postSchema, type PostData } from '@/lib/zod';
 import { upsertPost } from '@/lib/supabase';
 import { useImageValidation } from '@/hooks/useImageValidation';
+import { downscaleImageToCover } from '@/utils';
 import type { Post, PostOrientation } from '@/types';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -137,6 +138,12 @@ export function PostModal({
         const blob = await response.blob();
         const fileName = selectedPredesignedImage.split('/').pop() || 'predesigned-image.jpg';
         imageToUse = new File([blob], fileName, { type: blob.type });
+      }
+
+      // Downscale + crop uploads to the exact display ratio before storing, so
+      // the post fills the 16:9/9:16 frame without letterbox bars.
+      if (imageToUse) {
+        imageToUse = await downscaleImageToCover(imageToUse, activeOrientation);
       }
 
       const saved = await upsertPost(

--- a/src/components/ui/image-upload.tsx
+++ b/src/components/ui/image-upload.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { X, Image } from 'lucide-react';
-import { cn, formatFileRejectionError } from '@/utils';
+import { cn } from '@/utils';
 import { Label } from './label';
 import { VALID_IMAGE_TYPES } from '@/lib/zod';
 import type { PostOrientation } from '@/types';
@@ -56,10 +56,7 @@ export function ImageUpload({
     maxFiles: 1,
   });
 
-  const fileRejectionError =
-    fileRejections.length > 0
-      ? formatFileRejectionError(fileRejections[0].errors[0].message)
-      : null;
+  const fileRejectionError = fileRejections.length > 0 ? fileRejections[0].errors[0].message : null;
 
   const handleRemove = (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/src/components/ui/image-upload.tsx
+++ b/src/components/ui/image-upload.tsx
@@ -3,7 +3,7 @@ import { useDropzone } from 'react-dropzone';
 import { X, Image } from 'lucide-react';
 import { cn, formatFileRejectionError } from '@/utils';
 import { Label } from './label';
-import { VALID_IMAGE_TYPES, MAX_FILE_SIZE } from '@/lib/zod';
+import { VALID_IMAGE_TYPES } from '@/lib/zod';
 import type { PostOrientation } from '@/types';
 
 export interface ImageUploadProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
@@ -51,7 +51,7 @@ export function ImageUpload({
     accept: {
       'image/*': VALID_IMAGE_TYPES,
     },
-    maxSize: MAX_FILE_SIZE,
+    // No maxSize: oversized images are downscaled on upload rather than rejected.
     disabled,
     maxFiles: 1,
   });

--- a/src/hooks/useBackgroundImages.ts
+++ b/src/hooks/useBackgroundImages.ts
@@ -1,8 +1,7 @@
 import { useEffect, useState } from 'react';
 import { listFiles } from '@/lib/supabase/helpers';
+import { VALID_IMAGE_EXTENSIONS } from '@/lib/zod';
 import { SupabaseBuckets, SupabaseFolders, type BackgroundImage } from '@/types';
-
-const SUPPORTED_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp'];
 
 /**
  * Fetches the list of background images from the Supabase
@@ -21,7 +20,7 @@ export function useBackgroundImages() {
         const filtered = files
           .filter(f => {
             const ext = f.name.toLowerCase().split('.').pop();
-            return SUPPORTED_EXTENSIONS.includes(ext || '');
+            return VALID_IMAGE_EXTENSIONS.includes(ext || '');
           })
           .sort((a, b) => a.name.localeCompare(b.name));
         setImages(filtered);

--- a/src/lib/supabase/services/backgrounds.ts
+++ b/src/lib/supabase/services/backgrounds.ts
@@ -2,9 +2,7 @@ import { SupabaseBuckets, type BackgroundImage } from '@/types';
 import supabase from '../index';
 import { getMasjidMembership, uploadFile } from '../helpers';
 import { captureSupabaseError } from '@/lib/sentry';
-
-/** Extensions we surface in the uploaded-backgrounds grid. */
-const SUPPORTED_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp'];
+import { VALID_IMAGE_EXTENSIONS } from '@/lib/zod';
 
 // Uploads are scoped to a `<masjid_id>/` path prefix. RLS keeps the bucket
 // writable by any authenticated user; this prefix isolates one masjid's
@@ -46,7 +44,7 @@ export async function listUserBackgrounds(): Promise<BackgroundImage[]> {
     .filter(item => {
       if (!item.name || item.name.includes('/')) return false;
       const ext = item.name.toLowerCase().split('.').pop();
-      return SUPPORTED_EXTENSIONS.includes(ext || '');
+      return VALID_IMAGE_EXTENSIONS.includes(ext || '');
     })
     .map(item => {
       const filePath = `${masjid_id}/${item.name}`;

--- a/src/lib/zod.ts
+++ b/src/lib/zod.ts
@@ -75,6 +75,8 @@ export const masjidProfileSchema = z.object({
 export type MasjidProfileData = z.infer<typeof masjidProfileSchema>;
 
 export const VALID_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+/** File extensions surfaced when listing stored background images. */
+export const VALID_IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp'];
 export const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 
 export const announcementSchema = z.object({

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -14,7 +14,6 @@ export interface ImageValidationResult {
   error?: string;
   dimensions?: ImageDimensions;
   recommendation?: string;
-  quality?: 'minimum' | 'recommended' | 'excellent';
 }
 
 export interface ValidationConfig {
@@ -24,17 +23,8 @@ export interface ValidationConfig {
 }
 
 export interface DimensionLimits {
-  readonly min: { width: number; height: number };
   readonly recommended: { width: number; height: number };
   readonly max: { width: number; height: number };
-}
-
-export interface CropSuggestion {
-  width: number;
-  height: number;
-  ratio: string;
-  cropArea: number;
-  retainedPercentage: number;
 }
 
 export interface ValidationState {

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -26,15 +26,3 @@ export const isNullOrUndefined = <T>(value: T | null | undefined): value is null
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
-
-/**
- * Formats a dropzone file rejection error message to be more user-friendly
- * Converts byte values to MB in file size error messages
- */
-export function formatFileRejectionError(message: string): string {
-  return message.replace(
-    /File is larger than (\d+) bytes/,
-    (_, bytes) =>
-      `File is larger than ${(Number(bytes) / (1024 * 1024)).toFixed(0)}MB. Please use resizer tool to reduce the file size.`
-  );
-}

--- a/src/utils/image-resize.ts
+++ b/src/utils/image-resize.ts
@@ -1,0 +1,115 @@
+import type { PostOrientation } from '@/types';
+import { MAX_FILE_SIZE } from '@/lib/zod';
+import { getMaxDimensions } from './image-validation';
+
+/** JPEG quality used for the first re-encode attempt. */
+const INITIAL_QUALITY = 0.85;
+/** Lowest quality we will drop to while trying to fit under MAX_FILE_SIZE. */
+const MIN_QUALITY = 0.6;
+/** How much to lower quality on each retry when the encode is still too large. */
+const QUALITY_STEP = 0.1;
+/** Aspect-ratio deltas below this are treated as "already exact" (no crop). */
+const ASPECT_EPSILON = 0.005;
+
+/**
+ * Scales an image down to fit within the orientation's maximum display
+ * dimensions and center-crops it to the exact target aspect ratio (16:9 /
+ * 9:16), re-encoding as JPEG. Producing an exact-ratio image means it fills the
+ * full-screen display and every 16:9 preview without letterbox bars — matching
+ * the Ayat/Hadith snapshot, which is always an exact 1920×1080 frame.
+ *
+ * The crop is centered and the image is never upscaled. Images that already
+ * match the target ratio, fit within bounds, and are under the size cap are
+ * returned untouched.
+ *
+ * Callers should validate the aspect ratio first (see
+ * `validateImageForFullScreen`); the ±5% tolerance there bounds how much this
+ * ever crops (~2.5% per side at the extreme).
+ */
+export async function downscaleImageToCover(
+  file: File,
+  orientation: PostOrientation = 'landscape'
+): Promise<File> {
+  // Only attempt to process raster images we can decode.
+  if (!file.type.startsWith('image/')) return file;
+
+  const max = getMaxDimensions(orientation);
+  const targetAspect = max.width / max.height;
+
+  let bitmap: ImageBitmap;
+  try {
+    bitmap = await createImageBitmap(file);
+  } catch {
+    // Decoding failed (e.g. unsupported variant) — fall back to the original.
+    return file;
+  }
+
+  const srcW = bitmap.width;
+  const srcH = bitmap.height;
+  const srcAspect = srcW / srcH;
+
+  // Center-crop the source to the exact target aspect ratio.
+  let cropW = srcW;
+  let cropH = srcH;
+  if (srcAspect > targetAspect) {
+    cropW = srcH * targetAspect; // too wide — trim the sides
+  } else if (srcAspect < targetAspect) {
+    cropH = srcW / targetAspect; // too tall — trim top/bottom
+  }
+  const sx = (srcW - cropW) / 2;
+  const sy = (srcH - cropH) / 2;
+
+  // Scale the cropped region down to fit the max box (never upscale).
+  const scale = Math.min(1, max.width / cropW, max.height / cropH);
+  const targetWidth = Math.round(cropW * scale);
+  const targetHeight = Math.round(cropH * scale);
+
+  const aspectMatches = Math.abs(srcAspect - targetAspect) < ASPECT_EPSILON;
+  const needsResize = scale < 1;
+  const needsRecompress = file.size > MAX_FILE_SIZE;
+
+  // Already exact ratio, within bounds, and light enough — keep the original.
+  if (aspectMatches && !needsResize && !needsRecompress) {
+    bitmap.close();
+    return file;
+  }
+
+  const canvas = document.createElement('canvas');
+  canvas.width = targetWidth;
+  canvas.height = targetHeight;
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    bitmap.close();
+    return file; // Canvas unavailable — fall back to the original.
+  }
+
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = 'high';
+  ctx.drawImage(bitmap, sx, sy, cropW, cropH, 0, 0, targetWidth, targetHeight);
+  bitmap.close();
+
+  let quality = INITIAL_QUALITY;
+  let blob = await canvasToBlob(canvas, quality);
+  while (blob && blob.size > MAX_FILE_SIZE && quality > MIN_QUALITY) {
+    quality = Math.max(MIN_QUALITY, quality - QUALITY_STEP);
+    blob = await canvasToBlob(canvas, quality);
+  }
+
+  if (!blob) return file;
+
+  return new File([blob], renameToJpg(file.name), {
+    type: 'image/jpeg',
+    lastModified: file.lastModified,
+  });
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement, quality: number): Promise<Blob | null> {
+  return new Promise(resolve => canvas.toBlob(resolve, 'image/jpeg', quality));
+}
+
+function renameToJpg(name: string): string {
+  const dot = name.lastIndexOf('.');
+  const base = dot > 0 ? name.slice(0, dot) : name;
+  return `${base}.jpg`;
+}

--- a/src/utils/image-validation.ts
+++ b/src/utils/image-validation.ts
@@ -10,7 +10,7 @@ import type {
   ImageRequirement,
 } from '@/types/validation';
 import type { PostOrientation } from '@/types';
-import { MAX_FILE_SIZE, VALID_IMAGE_TYPES } from '@/lib/zod';
+import { VALID_IMAGE_TYPES } from '@/lib/zod';
 
 /** Allowed deviation from the target aspect ratio, as a fraction of the ratio. */
 const RATIO_TOLERANCE = 0.05;
@@ -59,6 +59,15 @@ const IMAGE_TYPE_LABELS: Record<string, string> = {
 };
 
 /**
+ * The maximum display dimensions for an orientation. Oversized uploads are
+ * scaled down to fit within these bounds (see `downscaleImageToFit`) rather
+ * than rejected, so this doubles as the resize target ceiling.
+ */
+export function getMaxDimensions(orientation: PostOrientation = 'landscape') {
+  return orientation === 'portrait' ? PORTRAIT_LIMITS.max : LANDSCAPE_LIMITS.max;
+}
+
+/**
  * Builds the human-readable list of upload requirements for an orientation.
  * Derived from the same constants the validator enforces, so the UI can never
  * advertise a limit that differs from what is actually checked.
@@ -68,10 +77,9 @@ export function getImageRequirements(
 ): ImageRequirement[] {
   const config = orientation === 'portrait' ? PORTRAIT_CONFIG : LANDSCAPE_CONFIG;
   const limits = orientation === 'portrait' ? PORTRAIT_LIMITS : LANDSCAPE_LIMITS;
-  const { min, recommended, max } = limits;
+  const { recommended, max } = limits;
 
   const formats = VALID_IMAGE_TYPES.map(type => IMAGE_TYPE_LABELS[type] ?? type).join(', ');
-  const maxSizeMb = Math.round(MAX_FILE_SIZE / (1024 * 1024));
 
   return [
     {
@@ -80,12 +88,12 @@ export function getImageRequirements(
       value: `${config.name} (±${Math.round(RATIO_TOLERANCE * 100)}% tolerance)`,
     },
     { key: 'formats', label: 'Formats', value: formats },
-    { key: 'size', label: 'Max file size', value: `${maxSizeMb}MB` },
+    { key: 'size', label: 'File size', value: 'Optimized automatically' },
     {
       key: 'resolution',
       label: 'Resolution',
-      value: `${min.width}×${min.height} to ${max.width}×${max.height}`,
-      hint: `${recommended.width}×${recommended.height} recommended for best quality.`,
+      value: 'Any size accepted',
+      hint: `Large images are scaled down to ${max.width}×${max.height} (${recommended.width}×${recommended.height} recommended).`,
     },
   ];
 }
@@ -171,22 +179,11 @@ function validateDimensions(
   const { width, height, aspectRatio } = dimensions;
   const config = orientation === 'portrait' ? PORTRAIT_CONFIG : LANDSCAPE_CONFIG;
   const limits = orientation === 'portrait' ? PORTRAIT_LIMITS : LANDSCAPE_LIMITS;
-  const { recommended, max } = limits;
+  const { recommended } = limits;
   const { ratio, tolerance, name } = config;
 
-  if (width > max.width || height > max.height) {
-    const maxLabel =
-      orientation === 'portrait' ? PORTRAIT_RESOLUTIONS.UHD_4K : LANDSCAPE_RESOLUTIONS.UHD_4K;
-    return {
-      isValid: false,
-      error: `Image resolution too high. Maximum allowed: ${maxLabel}`,
-      dimensions,
-      recommendation:
-        'Please resize or compress the image to reduce file size and improve loading performance.',
-      quality: 'excellent',
-    };
-  }
-
+  // Oversized images are no longer rejected here — they are downscaled to fit
+  // within `getMaxDimensions()` on upload. Aspect ratio is the only hard gate.
   const aspectRatioResult = validateAspectRatio(aspectRatio, ratio, tolerance, name, orientation);
   if (!aspectRatioResult.isValid) {
     return { ...aspectRatioResult, dimensions };

--- a/src/utils/image-validation.ts
+++ b/src/utils/image-validation.ts
@@ -3,7 +3,6 @@ import type {
   ImageValidationResult,
   ValidationConfig,
   DimensionLimits,
-  CropSuggestion,
   ImageQuality,
   ImageOrientation,
   ResolutionName,
@@ -28,27 +27,13 @@ const PORTRAIT_CONFIG: ValidationConfig = {
 } as const;
 
 const LANDSCAPE_LIMITS: DimensionLimits = {
-  min: { width: 1280, height: 720 },
   recommended: { width: 1920, height: 1080 },
   max: { width: 3840, height: 2160 },
 } as const;
 
 const PORTRAIT_LIMITS: DimensionLimits = {
-  min: { width: 720, height: 1280 },
   recommended: { width: 1080, height: 1920 },
   max: { width: 2160, height: 3840 },
-} as const;
-
-const LANDSCAPE_RESOLUTIONS = {
-  HD: '1280×720',
-  FULL_HD: '1920×1080',
-  UHD_4K: '3840×2160',
-} as const;
-
-const PORTRAIT_RESOLUTIONS = {
-  HD: '720×1280',
-  FULL_HD: '1080×1920',
-  UHD_4K: '2160×3840',
 } as const;
 
 const IMAGE_TYPE_LABELS: Record<string, string> = {
@@ -60,7 +45,7 @@ const IMAGE_TYPE_LABELS: Record<string, string> = {
 
 /**
  * The maximum display dimensions for an orientation. Oversized uploads are
- * scaled down to fit within these bounds (see `downscaleImageToFit`) rather
+ * scaled down to fit within these bounds (see `downscaleImageToCover`) rather
  * than rejected, so this doubles as the resize target ceiling.
  */
 export function getMaxDimensions(orientation: PostOrientation = 'landscape') {
@@ -196,7 +181,6 @@ function validateDimensions(
     isValid: true,
     dimensions,
     recommendation: `✓ Perfect ${name} aspect ratio confirmed.${recommendation ? ` ${recommendation}` : ''}`,
-    quality,
   };
 }
 
@@ -274,8 +258,8 @@ function generateQualityRecommendation(
   quality: ImageQuality,
   orientation: PostOrientation
 ): string {
-  const fullHd =
-    orientation === 'portrait' ? PORTRAIT_RESOLUTIONS.FULL_HD : LANDSCAPE_RESOLUTIONS.FULL_HD;
+  const { recommended } = orientation === 'portrait' ? PORTRAIT_LIMITS : LANDSCAPE_LIMITS;
+  const fullHd = `${recommended.width}×${recommended.height}`;
   switch (quality) {
     case 'minimum':
       return `For optimal quality, consider using ${fullHd} or higher.`;
@@ -331,31 +315,4 @@ function getResolutionName(width: number, height: number): ResolutionName {
   };
 
   return resolutionMap[`${width}x${height}`] || '';
-}
-
-/**
- * Suggests optimal cropping dimensions for the given image
- */
-export function suggestOptimalCrop(
-  dimensions: ImageDimensions,
-  orientation: PostOrientation = 'landscape'
-): CropSuggestion {
-  const { width, height } = dimensions;
-  const config = orientation === 'portrait' ? PORTRAIT_CONFIG : LANDSCAPE_CONFIG;
-  const { ratio, name } = config;
-
-  const cropWidth = Math.min(width, height * ratio);
-  const cropHeight = Math.min(height, width / ratio);
-
-  const originalArea = width * height;
-  const cropArea = cropWidth * cropHeight;
-  const retainedPercentage = Math.round((cropArea / originalArea) * 100);
-
-  return {
-    width: Math.round(cropWidth),
-    height: Math.round(cropHeight),
-    ratio: name,
-    cropArea: Math.round(cropArea),
-    retainedPercentage,
-  };
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,5 +12,6 @@ export * from './prayer-times-cache';
 export * from './online-status';
 export * from './prayer-card-images';
 export * from './image-validation';
+export * from './image-resize';
 export * from './password-strength';
 export * from './ayat-hadith';


### PR DESCRIPTION
## Summary

Reworks image uploads so oversized images are **automatically resized** instead of rejected, and cleans up the dead/redundant code this exposed.

### Behavior change
- Uploads are now gated only on **aspect ratio (±5%)** and **file type**.
- Oversized images are **center-cropped to the exact display ratio** (16:9 / 9:16) and downscaled to fit within the max display bounds, re-encoded as JPEG under 5 MB.
- Cropping to the exact ratio (vs scaling only) means stored images fill the full-screen display and every 16:9 preview **without letterbox bars**, matching the Ayat/Hadith snapshot behavior.

### Changes
- add `downscaleImageToCover` util (center-crop + downscale + JPEG re-encode)
- drop the max-resolution rejection from `validateImageForFullScreen`
- remove the 5 MB / size rejections from the background-tile and post upload paths
- remove the dropzone `maxSize` guard so large files reach validation
- update the requirements panel copy to reflect auto-optimization

### Cleanup (dead / redundant code)
- delete unused `suggestOptimalCrop()` + `CropSuggestion` type
- drop unused `min` dimension limits and `DimensionLimits.min`
- remove `*_RESOLUTIONS` consts (only `FULL_HD` was used and duplicated `recommended`)
- drop the never-read `quality` field from `ImageValidationResult`
- remove `formatFileRejectionError` (its size-message rewrite was unreachable after `maxSize` was dropped); surface the raw rejection message
- dedupe `SUPPORTED_EXTENSIONS` into a shared `VALID_IMAGE_EXTENSIONS` in `zod.ts`

## Notes
- Posts created **before** this change are still stored at their original ratio and would need re-uploading to pick up the crop.
- `tsc` and `eslint` pass clean.

## Test plan
- [ ] Upload an oversized (e.g. 8250×4500) image as a post → accepted, fills the 16:9 frame with no white bar
- [ ] Upload the same image as an Ayat/Hadith background → unchanged, no bar
- [ ] Upload a wrong-aspect-ratio image → still rejected with a clear message